### PR TITLE
[Coding standards] Do not use PHP closing tag

### DIFF
--- a/lib/Stash/Autoloader.php
+++ b/lib/Stash/Autoloader.php
@@ -84,15 +84,15 @@ class Autoloader
 	 */
 	static function autoload($classname)
 	{
-	
+
 		if(class_exists($classname, false))
 			return true;
-	
+
 		$classname = ltrim($classname);
-		
+
 		if(strpos($classname, 'Stash') !== 0)
 			return false;
-	
+
 		// Everything has at least one namespace (Stash)
 		if(strpos($classname, '\\', 1) === false)
 			return false;
@@ -103,7 +103,7 @@ class Autoloader
 
 		if(!file_exists($fileName))
 			return false;
-		
+
 		include($fileName);
 		return class_exists($classname, false) || interface_exists($classname, false);
 	}
@@ -119,4 +119,3 @@ define('STASH_SP_OLD', 1);
 define('STASH_SP_VALUE', 2);
 define('STASH_SP_SLEEP', 3);
 define('STASH_SP_PRECOMPUTE', 4);
-?>

--- a/lib/Stash/Box.php
+++ b/lib/Stash/Box.php
@@ -131,5 +131,3 @@ class Box
 		self::$handler = $handler;
 	}
 }
-
-?>

--- a/lib/Stash/Cache.php
+++ b/lib/Stash/Cache.php
@@ -781,5 +781,3 @@ class Cache
 		} // switch($invalidate)
 	}
 }
-
-?>

--- a/lib/Stash/Error.php
+++ b/lib/Stash/Error.php
@@ -46,4 +46,3 @@
 namespace Stash;
 
 class Error extends \Exception {}
-?>

--- a/lib/Stash/Handler.php
+++ b/lib/Stash/Handler.php
@@ -141,5 +141,3 @@ interface Handler
 	 */
 	static function canEnable();
 }
-
-?>

--- a/lib/Stash/Handlers.php
+++ b/lib/Stash/Handlers.php
@@ -113,5 +113,3 @@ class Handlers
 	}
 
 }
-
-?>

--- a/lib/Stash/Handlers/Apc.php
+++ b/lib/Stash/Handlers/Apc.php
@@ -207,5 +207,3 @@ class Apc implements \Stash\Handler
 		return $life;
 	}
 }
-
-?>

--- a/lib/Stash/Handlers/Ephemeral.php
+++ b/lib/Stash/Handlers/Ephemeral.php
@@ -63,7 +63,7 @@ class Ephemeral implements \Stash\Handler
 	{
 
 	}
-	
+
 	public function __destruct()
 	{
 	}
@@ -125,5 +125,3 @@ class Ephemeral implements \Stash\Handler
 		return (defined('TESTING') && TESTING);
 	}
 }
-
-?>

--- a/lib/Stash/Handlers/ExceptionTest.php
+++ b/lib/Stash/Handlers/ExceptionTest.php
@@ -101,4 +101,3 @@ class ExceptionTest implements \Stash\Handler
 }
 
 class StashExceptionTestError extends \Stash\Error {}
-?>

--- a/lib/Stash/Handlers/FileSystem.php
+++ b/lib/Stash/Handlers/FileSystem.php
@@ -415,4 +415,3 @@ class FileSystem implements \Stash\Handler
 }
 
 class StashFileSystemError extends \Stash\Error {}
-?>

--- a/lib/Stash/Handlers/Memcached.php
+++ b/lib/Stash/Handlers/Memcached.php
@@ -426,4 +426,3 @@ class StashMemcached_Memcache extends StashMemcached_Memcached
 
 class StashMemcachedError extends \Stash\Error {}
 class StashMemcached_MemcachedError extends \Stash\Error {}
-?>

--- a/lib/Stash/Handlers/MultiHandler.php
+++ b/lib/Stash/Handlers/MultiHandler.php
@@ -192,4 +192,3 @@ class MultiHandler implements \Stash\Handler
 }
 
 class StashMultiHandlerError extends \Stash\Error {}
-?>

--- a/lib/Stash/Handlers/Sqlite.php
+++ b/lib/Stash/Handlers/Sqlite.php
@@ -168,7 +168,7 @@ class Sqlite implements \Stash\Handler
 		{
 			if(!($handler = $this->getSqliteHandler($database, true)))
 				continue;
-			
+
 
 			isset($sqlKey) ? $handler->clear($sqlKey) : $handler->clear();
 			$handler->__destruct();
@@ -496,4 +496,3 @@ class Sqlite_PDO2 extends Sqlite_PDO
 }
 
 class StashSqliteError extends \Stash\Error {}
-?>

--- a/lib/Stash/Handlers/Xcache.php
+++ b/lib/Stash/Handlers/Xcache.php
@@ -221,4 +221,3 @@ class Xcache extends Apc
 }
 
 class StashXcacheError extends \Stash\Error {}
-?>

--- a/lib/Stash/Manager.php
+++ b/lib/Stash/Manager.php
@@ -163,4 +163,3 @@ class Manager
 }
 
 class StashManagerError extends Error {}
-?>

--- a/lib/Stash/Utilities.php
+++ b/lib/Stash/Utilities.php
@@ -237,5 +237,3 @@ class Utilities
 		return $pKey;
 	}
 }
-
-?>

--- a/lib/Stash/Warning.php
+++ b/lib/Stash/Warning.php
@@ -46,4 +46,3 @@
 namespace Stash;
 
 class Warning extends Error {}
-?>


### PR DESCRIPTION
As they can be problematic sometimes.

Notes: 
- Merge it if you like it only,
- My IDE is configured to strip trailing spaces which I think is good, let me know if you prefer to keep wss.
