### PR TITLE
Changed the "store" function name to "set"

### DIFF
--- a/src/Stash/Cache.php
+++ b/src/Stash/Cache.php
@@ -72,7 +72,7 @@ use Stash\Exception\InvalidArgumentException;
  *      $data = runExpensiveCode();
  *
  *      // Save the code for later.
- *      $cache->store($data);
+ *      $cache->set($data);
  * }
  * </code>
  *
@@ -529,17 +529,17 @@ class Cache
      * @param int|DateTime|null $time How long the item should be stored. Int is time (seconds), DateTime a future date
      * @return bool Returns whether the object was successfully stored or not.
      */
-    public function store($data, $time = null)
+    public function set($data, $time = null)
     {
         try {
-            return $this->executeStore($data, $time);
+            return $this->executeSet($data, $time);
         } catch (Exception $e) {
             $this->disable();
             return false;
         }
     }
 
-    private function executeStore($data, $time)
+    private function executeSet($data, $time)
     {
         if ($this->isDisabled()) {
             return false;
@@ -601,7 +601,7 @@ class Cache
             return false;
         }
 
-        return $this->store($this->get());
+        return $this->set($this->get());
     }
 
     /**

--- a/tests/Stash/Test/AbstractCacheTest.php
+++ b/tests/Stash/Test/AbstractCacheTest.php
@@ -88,7 +88,7 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
         $stash->setupKey();
     }
 
-    public function testStore()
+    public function testSet()
     {
         foreach ($this->data as $type => $value) {
             $key = array('base', $type);
@@ -97,12 +97,12 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
             $this->assertAttributeInternalType('string', 'keyString', $stash, 'Argument based keys setup keystring');
             $this->assertAttributeInternalType('array', 'key', $stash, 'Argument based keys setup key');
 
-            $this->assertTrue($stash->store($value), 'Handler class able to store data type ' . $type);
+            $this->assertTrue($stash->set($value), 'Handler class able to store data type ' . $type);
         }
     }
 
     /**
-     * @depends testStore
+     * @depends testSet
      */
     public function testGet()
     {
@@ -124,7 +124,7 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
 
         $runningStash = $this->testConstruct();
         $runningStash->setupKey($key);
-        $runningStash->store($oldValue, -300);
+        $runningStash->set($oldValue, -300);
 
 
         // Test without stampede
@@ -189,7 +189,7 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
 
 
         // Test that storing the cache turns off stampede mode.
-        $runningStash->store($newValue, 30);
+        $runningStash->set($newValue, 30);
         $this->assertAttributeEquals(false, 'stampedeRunning', $runningStash, 'Stampede flag is off.');
         unset($runningStash);
 
@@ -212,7 +212,7 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
 
     }
 
-    public function testStoreWithDateTime()
+    public function testSetWithDateTime()
     {
 
         $expiration = new \DateTime('now');
@@ -221,7 +221,7 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
         $key = array('base', 'expiration', 'test');
         $stash = $this->testConstruct();
         $stash->setupKey($key);
-        $stash->store(array(1, 2, 3, 'apples'), $expiration);
+        $stash->set(array(1, 2, 3, 'apples'), $expiration);
 
         $stash = $this->testConstruct();
         $stash->setupKey($key);
@@ -247,11 +247,11 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
             $key = array('base', $type);
             $stash = $this->testConstruct();
             $stash->setupKey($key);
-            $stash->store($value);
+            $stash->set($value);
             $this->assertAttributeInternalType('string', 'keyString', $stash, 'Argument based keys setup keystring');
             $this->assertAttributeInternalType('array', 'key', $stash, 'Argument based keys setup key');
 
-            $this->assertTrue($stash->store($value), 'Handler class able to store data type ' . $type);
+            $this->assertTrue($stash->set($value), 'Handler class able to store data type ' . $type);
         }
 
         foreach ($this->data as $type => $value) {
@@ -284,7 +284,7 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
             $key = array('base', $type);
             $stash = $this->testConstruct();
             $stash->setupKey($key);
-            $stash->store($value);
+            $stash->set($value);
         }
 
         // clear
@@ -310,14 +310,14 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
             $key = array('base', 'fresh', $type);
             $stash = $this->testConstruct();
             $stash->setupKey($key);
-            $stash->store($value);
+            $stash->set($value);
         }
 
         foreach ($this->data as $type => $value) {
             $key = array('base', 'stale', $type);
             $stash = $this->testConstruct();
             $stash->setupKey($key);
-            $stash->store($value, -600);
+            $stash->set($value, -600);
         }
 
         $this->assertTrue($stash->purge());
@@ -345,7 +345,7 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
 
             $stash = $this->testConstruct();
             $stash->setupKey($key);
-            $stash->store($value, -600);
+            $stash->set($value, -600);
 
             $stash = $this->testConstruct();
             $stash->setupKey($key);
@@ -418,7 +418,7 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
 
     private function assertMemoryOnlyStash(Cache $stash)
     {
-        $this->assertFalse($stash->store('true'), 'storeData returns false for memory only cache');
+        $this->assertFalse($stash->set('true'), 'storeData returns false for memory only cache');
         $this->assertNull($stash->get(), 'getData returns null for memory only cache');
         $this->assertTrue($stash->clear(), 'clear returns true for memory only cache');
         $this->assertTrue($stash->purge(), 'purge returns true for memory only cache');
@@ -429,7 +429,7 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
 
     private function assertDisabledStash(Cache $stash)
     {
-        $this->assertFalse($stash->store('true'), 'storeData returns false for disabled cache');
+        $this->assertFalse($stash->set('true'), 'storeData returns false for disabled cache');
         $this->assertNull($stash->get(), 'getData returns null for disabled cache');
         $this->assertFalse($stash->clear(), 'clear returns false for disabled cache');
         $this->assertFalse($stash->purge(), 'purge returns false for disabled cache');

--- a/tests/Stash/Test/BoxTest.php
+++ b/tests/Stash/Test/BoxTest.php
@@ -33,7 +33,7 @@ class BoxTest extends \PHPUnit_Framework_TestCase
     {
         $stash = Box::getCache('base', 'one');
         $this->assertInstanceOf('Stash\Cache', $stash, 'getCache returns a Stash\Cache object');
-        $stash->store($this->data);
+        $stash->set($this->data);
         $storedData = $stash->get();
         $this->assertEquals($this->data, $storedData, 'getCache returns working Stash\Cache object');
     }
@@ -41,7 +41,7 @@ class BoxTest extends \PHPUnit_Framework_TestCase
     public function testClearCache()
     {
         $stash = Box::getCache('base', 'one');
-        $stash->store($this->data, -600);
+        $stash->set($this->data, -600);
         $this->assertTrue(Box::clearCache('base', 'one'), 'clear returns true');
 
         $stash = Box::getCache('base', 'one');
@@ -52,7 +52,7 @@ class BoxTest extends \PHPUnit_Framework_TestCase
     public function testPurgeCache()
     {
         $stash = Box::getCache('base', 'one');
-        $stash->store($this->data, -600);
+        $stash->set($this->data, -600);
         $this->assertTrue(Box::purgeCache(), 'purge returns true');
 
         $stash = Box::getCache('base', 'one');

--- a/tests/Stash/Test/CacheExceptionTest.php
+++ b/tests/Stash/Test/CacheExceptionTest.php
@@ -20,13 +20,13 @@ use Stash\Cache;
  */
 class CacheExceptionTest extends \PHPUnit_Framework_TestCase
 {
-    public function testStore()
+    public function testSet()
     {
         $handler = new ExceptionTest();
         $stash = new Cache($handler);
         $stash->setupKey('path', 'to', 'store');
         $this->assertFalse($stash->isDisabled());
-        $this->assertFalse($stash->store(array(1, 2, 3), 3600));
+        $this->assertFalse($stash->set(array(1, 2, 3), 3600));
         $this->assertTrue($stash->isDisabled(), 'Is disabled after exception is thrown in handler');
     }
 

--- a/tests/Stash/Test/Handler/MemcacheTest.php
+++ b/tests/Stash/Test/Handler/MemcacheTest.php
@@ -71,13 +71,13 @@ class MemcacheTest extends AbstractHandlerTest
 
         $stash = new Cache($handler);
         $stash->setupKey($key);
-        $this->assertTrue($stash->store($key), 'Able to load and store memcache handler using multiple servers');
+        $this->assertTrue($stash->set($key), 'Able to load and store memcache handler using multiple servers');
 
         $options = array();
         $options['extension'] = $this->extension;
         $handler = new Memcache($options);
         $stash = new Cache($handler);
         $stash->setupKey($key);
-        $this->assertTrue($stash->store($key), 'Able to load and store memcache handler using default server');
+        $this->assertTrue($stash->set($key), 'Able to load and store memcache handler using default server');
     }
 }

--- a/tests/Stash/Test/ManagerTest.php
+++ b/tests/Stash/Test/ManagerTest.php
@@ -36,7 +36,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     {
         $stash = Manager::getCache('base', 'one');
         $this->assertInstanceOf('Stash\Cache', $stash, 'getCache returns a Stash\Cache object');
-        $stash->store($this->data);
+        $stash->set($this->data);
         $storedData = $stash->get();
         $this->assertEquals($this->data, $storedData, 'getCache returns working Stash object');
     }
@@ -44,7 +44,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testClearCache()
     {
         $stash = Manager::getCache('base', 'one');
-        $stash->store($this->data, -600);
+        $stash->set($this->data, -600);
         $this->assertTrue(Manager::clearCache('base', 'one'), 'clear returns true');
 
         $stash = Manager::getCache('base', 'one');
@@ -55,7 +55,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     public function testPurgeCache()
     {
         $stash = Manager::getCache('base', 'one');
-        $stash->store($this->data, -600);
+        $stash->set($this->data, -600);
         $this->assertTrue(Manager::purgeCache('base'), 'purge returns true');
 
         $stash = Manager::getCache('base', 'one');


### PR DESCRIPTION
[![Build Status](https://secure.travis-ci.org/tedivm/Stash.png?branch=store_to_set)](http://travis-ci.org/tedivm/Stash)

Since most libraries and the existing PSR's use "set" instead of "store" as a function name I feel an update is in order, especially since we've already broken so much other backwards compatibility things between the last release.
