### PR TITLE
Updated Sqlite handler to throw an exception when no handler is present.

### DIFF
--- a/src/Stash/Handler/Sqlite.php
+++ b/src/Stash/Handler/Sqlite.php
@@ -78,7 +78,7 @@ class Sqlite implements HandlerInterface
         } elseif(count($subhandlers) > 0 && $extension == 'any') {
             $handler = reset($subhandlers);
         } else {
-            $handler = null;
+            throw new RuntimeException('No sqlite extension available.');
         }
 
         $this->handlerClass = $handler;


### PR DESCRIPTION
[![Build Status](https://secure.travis-ci.org/jhallbachner/Stash.png?branch=sqlite_error_fix)](http://travis-ci.org/jhallbachner/Stash)

This brings the Sqlite handler back into consistency with the Memcache handler.
