### PR TITLE
Sessions Support

### DIFF
--- a/src/Stash/Session.php
+++ b/src/Stash/Session.php
@@ -66,6 +66,9 @@ class Session implements SessionHandlerInterface
      */
     static function registerHandler(Session $handler)
     {
+        // this isn't possible to test with the CLI phpunit test
+        // @codeCoverageIgnoreStart
+
         if(version_compare(PHP_VERSION, '5.4.0') >= 0)
         {
             return session_set_save_handler($handler, true);
@@ -87,6 +90,8 @@ class Session implements SessionHandlerInterface
 
             return true;
         }
+
+        // @codeCoverageIgnoreStop
     }
 
     /**
@@ -113,7 +118,7 @@ class Session implements SessionHandlerInterface
      */
     public function setOptions($options = array())
     {
-        $this->options = array_merge_recursive($this->options, $options);
+        $this->options = array_merge($this->options, $options);
     }
 
 

--- a/src/Stash/Session/SessionHandlerInterface.php
+++ b/src/Stash/Session/SessionHandlerInterface.php
@@ -17,8 +17,14 @@ namespace Stash\Session;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
+
+// It's impossible to get complete code coverage because of the different
+// php versions involved.
+
+// @codeCoverageIgnoreStart
 if(version_compare(phpversion(), '5.4.0', '>=')){
     interface SessionHandlerInterface extends \SessionHandlerInterface {}
 }else{
     interface SessionHandlerInterface {}
 }
+//@codeCoverageIgnoreStart

--- a/tests/Stash/Test/SessionTest.php
+++ b/tests/Stash/Test/SessionTest.php
@@ -101,7 +101,18 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
     public function testGarbageCollect()
     {
+        $pool = new Pool();
 
+        $sessionA = new Session($pool);
+        $sessionA->setOptions(array('ttl' => -30));
+        $sessionA->write('session_id', "session_a_data");
+
+        $sessionB = new Session($pool);
+        $sessionB->gc(null);
+
+        $sessionC = new Session($pool);
+        $this->assertSame('', $sessionC->read('session_id'),
+                          'Purged session returns empty string.');
     }
 
 }


### PR DESCRIPTION
This pull request allows Pool objects to be used as session handlers by PHP. 

It provides a new class, Stash\Session, which takes in a Pool class and uses it for session storage. The class inherits the new php5.4 SessionHandlerInterface but is also backwards compatible with php5.3.
