### PR TITLE
Add Ephemeral to the Handlers class

### DIFF
--- a/src/Stash/Handlers.php
+++ b/src/Stash/Handlers.php
@@ -25,6 +25,7 @@ class Handlers
      * @var array
      */
     protected static $handlers = array('Apc' => '\Stash\Handler\Apc',
+                                       'Ephemeral' => '\Stash\Handler\Ephemeral',
                                        'FileSystem' => '\Stash\Handler\FileSystem',
                                        'Memcache' => '\Stash\Handler\Memcache',
                                        'MultiHandler' => '\Stash\Handler\MultiHandler',


### PR DESCRIPTION
The Ephemeral handler is now a fully-supported handler and will be constructed directly by factories when in-memory storage is desirable. As such, the Handlers class should return it so it can easily be directly instantiated by external code. 
