### PR TITLE
Cleaned the use of unset on properties

### DIFF
--- a/src/Stash/Driver/Sub/Sqlite.php
+++ b/src/Stash/Driver/Sub/Sqlite.php
@@ -48,7 +48,7 @@ class Sqlite
 
     public function __destruct()
     {
-        unset($this->driver);
+        $this->driver = null;
     }
 
     public function get($key)
@@ -99,7 +99,7 @@ class Sqlite
 
         if (!isset($key)) {
             unset($driver);
-            unset($this->driver);
+            $this->driver = null;
             $this->driver = false;
             \Stash\Utilities::deleteRecursive($this->path);
         } else {

--- a/tests/Stash/Test/AbstractCacheTest.php
+++ b/tests/Stash/Test/AbstractCacheTest.php
@@ -310,7 +310,7 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
 
     public function testExtendCache()
     {
-        unset($this->driver);
+        $this->driver = null;
         foreach ($this->data as $type => $value) {
             $key = array('base', $type);
 


### PR DESCRIPTION
Unsetting a property does not unset the value but removes the property
from the class definition for the instance.
