### PR TITLE
Update $drivers to contain BackHole

### DIFF
--- a/src/Stash/Drivers.php
+++ b/src/Stash/Drivers.php
@@ -25,6 +25,7 @@ class Drivers
      * @var array
      */
     protected static $drivers = array('Apc' => '\Stash\Driver\Apc',
+                                       'BlackHole' => '\Stash\Driver\BlackHole',
                                        'Ephemeral' => '\Stash\Driver\Ephemeral',
                                        'FileSystem' => '\Stash\Driver\FileSystem',
                                        'Memcache' => '\Stash\Driver\Memcache',


### PR DESCRIPTION
Needed for StashBundle to be able to use this as a fallback.
