### PR TITLE
FileSystem driver now tries to create cache folder before throwing InvalidArgumentException

### DIFF
--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -384,8 +384,8 @@ class FileSystem implements DriverInterface
             throw new RuntimeException('Cache path was not set correctly.');
         }
 
-        if(!is_dir($this->cachePath)) {
-            throw new InvalidArgumentException('Cache path is not a directory.');
+        if(!is_dir($this->cachePath) && !@mkdir( $this->cachePath, $this->dirPermissions, true )) {
+            throw new InvalidArgumentException('Failed to create cache path.');
         }
 
         if(!is_writable($this->cachePath)) {


### PR DESCRIPTION
Hello

Fixes https://github.com/tedivm/TedivmStashBundle/issues/15

This is a very small change allowing `FileSystem` driver to try to create the cache folder if it doesn't already exist. If folder creation fails, then the exception is thrown.

Note the usage of the silent operator (`@`). It's here only to avoid a verbose warning if folder creation fails since we want to throw an exception.
