### PR TITLE
Remove tests folder from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
   },
   "autoload": {
     "psr-0": {
-     	"Stash": "src/",
-     	"Stash\\Test": "tests/"
+     	"Stash": "src/"
      }
   }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,4 +24,5 @@ if (!file_exists($filename)) {
     $filename = __DIR__ .'/../autoload.php';
 }
 
-require_once $filename;
+$loader = require_once $filename;
+$loader->add('Stash\\Test', __DIR__);


### PR DESCRIPTION
Hey, 

i remove the `tests` folder from the `composer.json`. This will improve the performance a little bit at the runtime. The tests folder is only loaded for the unit tests. 
