### PR TITLE
[FIX] Pool class PHPDoc fix for code completion

### DIFF
--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -46,7 +46,7 @@ class Pool
      * @example $cache = $pool->getItem('permissions', 'user', '4', '2');
      *
      * @param string|array $key, $key, $key...
-     * @return Stash\Item
+     * @return \Stash\Item
      */
     function getItem()
     {


### PR DESCRIPTION
In IDE function getItem return Stash\Item, must return \Stash\Item.
