### PR TITLE
Fixed file checks in FileSystem and Sqlite handlers.

### DIFF
--- a/src/Stash/Driver/Apc.php
+++ b/src/Stash/Driver/Apc.php
@@ -141,7 +141,8 @@ class Apc implements DriverInterface
      */
     static public function isAvailable()
     {
-        return extension_loaded('apc') && ini_get('apc.enabled');
+        return (extension_loaded('apc') && ini_get('apc.enabled'))
+            && ((php_sapi_name() !== 'cli') || ini_get('apc.enable_cli'));
     }
 
     protected function makeKey($key)

--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -384,6 +384,10 @@ class FileSystem implements DriverInterface
             throw new RuntimeException('Cache path was not set correctly.');
         }
 
+        if(file_exists($this->cachePath) && !is_dir($this->cachePath)) {
+            throw new InvalidArgumentException('Cache path is not a directory.');
+        }
+
         if(!is_dir($this->cachePath) && !@mkdir( $this->cachePath, $this->dirPermissions, true )) {
             throw new InvalidArgumentException('Failed to create cache path.');
         }


### PR DESCRIPTION
This PR introduces consistency between the FileSystem and Sqlite handlers regarding their checks on the filesystem, as well as adding an additional check to more clearly report the difference between a non-directory file living at the filepath and any other types of directory-creation failure.
