### PR TITLE
Tweaked Redis driver and Drivers class

### DIFF
--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -65,12 +65,12 @@ class Redis implements DriverInterface
 
 
 
-        if(isset($server['socket'])) {
+        if(isset($server['socket']) && $server['socket']) {
             $redis->connect($server['socket']);
         }else{
-            $port = isset($server['port']) ? $server['port'] : 6369;
+            $port = isset($server['port']) ? $server['port'] : 6379;
             $ttl = isset($server['ttl']) ? $server['ttl'] : 0.1;
-            $redis->connect($server['host'], $port, $ttl);
+            $redis->connect($server['server'], $port, $ttl);
         }
 
         // auth - just password

--- a/src/Stash/Drivers.php
+++ b/src/Stash/Drivers.php
@@ -26,10 +26,11 @@ class Drivers
      */
     protected static $drivers = array('Apc' => '\Stash\Driver\Apc',
                                        'BlackHole' => '\Stash\Driver\BlackHole',
+                                       'Composite' => '\Stash\Driver\Composite',
                                        'Ephemeral' => '\Stash\Driver\Ephemeral',
                                        'FileSystem' => '\Stash\Driver\FileSystem',
                                        'Memcache' => '\Stash\Driver\Memcache',
-                                       'Composite' => '\Stash\Driver\Composite',
+                                       'Redis' => '\Stash\Driver\Redis',
                                        'SQLite' => '\Stash\Driver\Sqlite',
                                        'Xcache' => '\Stash\Driver\Xcache',
     );
@@ -52,7 +53,7 @@ class Drivers
                 continue;
             }
 
-            if($name == 'MultiDriver') {
+            if($name == 'Composite') {
                 $availableDrivers[$name] = $class;
             } else {
                 if($class::isAvailable()) {


### PR DESCRIPTION
Some minor changes to support bundle integration:
- Force socket to be true in order to be activated.
- Change "host" to "server" to make interface consistent between Memcache and Redis.
- Added Redis to the list of drivers.

I also fixed an unrelated old reference to the MultiHandler in the Drivers class.
