### PR TITLE
Added sleep period between redis start

### DIFF
--- a/tests/travis/redis_setup.sh
+++ b/tests/travis/redis_setup.sh
@@ -24,4 +24,5 @@ sudo chown redis:redis /var/lib/redis2
 echo "Starting Second Service..."
 
 sudo service redis-server2 start
+sleep 3
 echo "Finished setup of second redis server."


### PR DESCRIPTION
This makes sure that redis is actually running when the test suites run.
