### PR TITLE
Added new test for keys with lots of nested sub keys.

### DIFF
--- a/tests/Stash/Test/Driver/AbstractDriverTest.php
+++ b/tests/Stash/Test/Driver/AbstractDriverTest.php
@@ -36,7 +36,8 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
                                                               )
                                                               )
                             ),
-                            '@node' => 'stuff'
+                            '@node' => 'stuff',
+                            'test/of/really/long/key/with/lots/of/children/keys' => true
     );
 
     protected $expiration;


### PR DESCRIPTION
Added a new test for each driver that tests for large keys. Now elements with 10 "stacks" in their key will get tested.

This is primarily for ticket #61.
