### PR TITLE
Utilities::deleteRecursive now works with Windows Absolute Paths

### DIFF
--- a/src/Stash/Utilities.php
+++ b/src/Stash/Utilities.php
@@ -121,7 +121,7 @@ class Utilities
      */
     public static function deleteRecursive($file)
     {
-        if (substr($file, 0, 1) !== '/' && substr($file, 1, 2) !== ':\\') {
+        if (!preg_match('/^(?:\/|\\\\|\w:\\\\|\w:\/).*$/', $file)) {
             throw new RuntimeException('deleteRecursive function requires an absolute path.');
         }
 


### PR DESCRIPTION
The second part of the conditional was removed because it's impossible for it ever to evalulate as true.
