### PR TITLE
getCreatedOn and getExpiration methods and tests

### DIFF
--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -512,6 +512,35 @@ class Item implements ItemInterface
     }
 
     /**
+     * Returns the record's createdOn timestamp or null if no createdOn timestamp is set
+     *
+     * @return int timestamp
+     */
+    public function getCreatedOn()
+    {
+        $record = $this->getRecord();
+        if (!isset($record['data']['createdOn'])) {
+            return null;
+        }
+        return $record['data']['createdOn'];
+    }
+
+    /**
+     * Returns the record's expiration timestamp or null if no expiration timestamp is set
+     *
+     * @return int timestamp
+     */
+    public function getExpiration()
+    {
+        $record = $this->getRecord();
+        if (!isset($record['expiration'])) {
+            return null;
+        }
+        return $record['expiration'];
+    }
+
+
+    /**
      * This function is used by the Pool object while creating this object. It
      * is an internal function an should not be called directly.
      *

--- a/tests/Stash/Test/AbstractCacheTest.php
+++ b/tests/Stash/Test/AbstractCacheTest.php
@@ -224,6 +224,46 @@ abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testGetCreatedOn()
+    {
+
+        $expiration = new \DateTime('now');
+        $expiration->add(new \DateInterval('PT10S')); // expire 10 seconds after createdOn
+        $expirationTS = $expiration->getTimestamp();
+
+        $key = array('getCreatedOn', 'test');
+        $stash = $this->testConstruct($key);
+
+        $this->assertNull($stash->getCreatedOn(), 'no record exists yet, return null');
+
+        $stash->set(array('stuff'), $expiration);
+
+        $stash = $this->testConstruct($key);
+        $createdOn = $stash->getCreatedOn();
+        $this->assertEquals($expirationTS - 10, $createdOn, 'createdOn is 10 seconds before expiration');
+
+    }
+
+    public function testGetExpiration()
+    {
+
+        $expiration = new \DateTime('now');
+        $expiration->add(new \DateInterval('P1D'));
+        $expirationTS = $expiration->getTimestamp();
+
+        $key = array('getExpiration', 'test');
+        $stash = $this->testConstruct($key);
+
+        $this->assertNull($stash->getExpiration(), 'no record exists yet, return null');
+
+        $stash->set(array('stuff'), $expiration);
+
+        $stash = $this->testConstruct($key);
+        $itemExpiration = $stash->getExpiration();
+        $this->assertLessThanOrEqual($expirationTS, $itemExpiration, 'sometime before explicitly set expiration');
+
+    }
+
     public function testIsMiss()
     {
         $stash = $this->testConstruct(array('This', 'Should', 'Fail'));


### PR DESCRIPTION
This adds two methods which reveal a record's expiration and createdOn timestamps, if they exist. I also added two tests to the AbstractCacheTest file, though they're fairly simple. Based on existing methods, both of these return `null` if the record doesn't exist or a timestamp can't be returned. 

All local non-skipped phpunit tests are passing (45 skipped, no redis, etc). All tests in AbstractCacheTest pass. [Travis passes](https://travis-ci.org/joemaller/Stash/builds/18599179) too.

Thanks to @Ninestein in #68
