### PR TITLE
Fixed bug in setItemClass, added additional tests

### DIFF
--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -76,11 +76,14 @@ class Pool implements PoolInterface
             throw new \InvalidArgumentException('Item class ' . $class
                                                 . ' does not exist');
 
-        if(!($class instanceof \Stash\Interfaces\ItemInterface))
+        $interfaces = class_implements($class, true);
+
+        if(!in_array('Stash\Interfaces\ItemInterface', $interfaces))
             throw new \InvalidArgumentException('Item class ' . $class
                     . ' must inherit from \Stash\Interfaces\ItemInterface');
 
         $this->itemClass = $class;
+        return true;
     }
 
     /**

--- a/tests/Stash/Test/PoolTest.php
+++ b/tests/Stash/Test/PoolTest.php
@@ -34,6 +34,16 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeInstanceOf('Stash\Driver\Ephemeral', 'driver', $stash, 'set driver is pushed to new stash objects');
     }
 
+    public function testSetItemClass()
+    {
+        $mockItem = $this->getMock('Stash\Interfaces\ItemInterface');
+        $mockClassName = get_class($mockItem);
+        $pool = $this->getTestPool();
+
+        $this->assertTrue($pool->setItemClass($mockClassName));
+        $this->assertAttributeEquals($mockClassName, 'itemClass', $pool);
+    }
+
     public function testGetItem()
     {
         $pool = $this->getTestPool();


### PR DESCRIPTION
This function allows Items to be created by the Pool class using different, developer defined classes. 
