### PR TITLE
Fixed dirpath generation on OSX with Filesystem driver

### DIFF
--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -181,7 +181,7 @@ class FileSystem implements DriverInterface
         if (!file_exists($path)) {
             if (!is_dir(dirname($path))) {
                 // MAX_PATH is 260 - http://msdn.microsoft.com/en-us/library/aa365247(VS.85).aspx
-                if (strlen(dirname($path)) > 259 && stristr(PHP_OS,'WIN')) {
+                if (strlen(dirname($path)) > 259 && stripos(PHP_OS,'WIN') === 0) {
                     throw new Stash\Exception\WindowsPathMaxLengthException();
                 }
 
@@ -191,7 +191,7 @@ class FileSystem implements DriverInterface
             }
 
             // MAX_PATH is 260 - http://msdn.microsoft.com/en-us/library/aa365247(VS.85).aspx
-            if (strlen($path) > 259 &&  stristr(PHP_OS,'WIN')) {
+            if (strlen($path) > 259 &&  stripos(PHP_OS,'WIN') === 0) {
                 throw new Stash\Exception\WindowsPathMaxLengthException();
             }
 


### PR DESCRIPTION
Since 43729fb, Filesystem driver checks path length for Windows (limited to 260 chars by Microsoft).
However, Windows check is made with `stristr(PHP_OS,'WIN')`, which makes it search for `WIN` string in all `PHP_OS`. This makes it fail on OSX, where `PHP_OS` == `Darwin`.

This patch checks if `WIN` is at the beginning of `PHP_OS` string. According to [PHP doc](http://fr2.php.net/php_uname), value on Windows can be `WIN32`, `WINNT` or `Windows`.
