### PR TITLE
Prevent autoload trigger when checking for ApcIterator

### DIFF
--- a/src/Stash/Driver/Apc.php
+++ b/src/Stash/Driver/Apc.php
@@ -145,7 +145,7 @@ class Apc implements DriverInterface
     public static function isAvailable()
     {
         // HHVM has some of the APC extension, but not all of it.
-        if(!class_exists('\APCIterator'))
+        if(!class_exists('\APCIterator', false))
             return false;
 
         return (extension_loaded('apc') && ini_get('apc.enabled'))


### PR DESCRIPTION
The class is either builtin or not availabe, therefore autoloading isn't necessary
