### PR TITLE
Check if directory exists before trying to create it

### DIFF
--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -185,7 +185,7 @@ class FileSystem implements DriverInterface
                     throw new Stash\Exception\WindowsPathMaxLengthException();
                 }
 
-                if (!mkdir(dirname($path), $this->dirPermissions, true)) {
+                if (!is_dir(dirname($path)) && !mkdir(dirname($path), $this->dirPermissions, true)) {
                     return false;
                 }
             }


### PR DESCRIPTION
Added a check if the cache directory already exists before trying to create it in the filesystem driver. Otherwise php throws a warning if the directory already exists.
