### PR TITLE
Added testing support for 5.6 and hhvm-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ php:
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
     - hhvm
+    - hhvm-nightly
 
 before_script:
     - composer self-update && composer install --dev
@@ -19,3 +21,7 @@ after_script:
 services:
   - redis-server
   - memcached
+
+matrix:
+    allow_failures:
+      - php: hhvm-nightly

--- a/tests/travis/php_setup.sh
+++ b/tests/travis/php_setup.sh
@@ -9,7 +9,7 @@ echo "**************************"
 echo ""
 echo "PHP Version: $TRAVIS_PHP_VERSION"
 
-if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then
+if [ "$TRAVIS_PHP_VERSION" = "hhvm" ] || [ "$TRAVIS_PHP_VERSION" = "hhvm-nightly" ]; then
     echo "Unable to install php extensions on current system"
 
 else


### PR DESCRIPTION
We like it when people upgrade to the latest version of php so we're supporting 5.6 out of the gate. 

Testing against hhvm-nightly builds will help us identity any problems that need to be reported back to the HHVM project, while also keeping compatibility issues in mind. Since it's against a dev version we're not enforcing that the tests pass (which we _are_ doing with hhvm).
