### PR TITLE
Destroy the stampede lock on item destruction

### DIFF
--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -561,6 +561,18 @@ class Item implements ItemInterface
     }
 
     /**
+     * This clears out any locks that are present if this Item is prematurely destructed.
+     */
+    public function __destruct()
+    {
+        if (isset($this->stampedeRunning) && $this->stampedeRunning == true) {
+            $spkey = $this->key;
+            $spkey[0] = 'sp';
+            $this->driver->clear($spkey);
+        }
+    }
+
+    /**
      * This function is used by the Pool object while creating this object. It
      * is an internal function an should not be called directly.
      *


### PR DESCRIPTION
When an Item is destroyed before it is able to set it's value and clear it's active lock it will now get cleared out.
