### PR TITLE
enable redis array options

### DIFF
--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -27,6 +27,18 @@ class Redis implements DriverInterface
     protected $redis;
     protected $keyCache = array();
 
+    protected $redisArrayOptionNames = array(
+        "previous",
+        "function",
+        "distributor",
+        "index",
+        "autorehash",
+        "pconnect",
+        "retry_interval",
+        "lazy_connect",
+        "connect_timeout",
+    );
+
     /**
      *
      * @param array $options
@@ -75,20 +87,8 @@ class Redis implements DriverInterface
 
         } else {
 
-            $redisArrayOptionNames = array(
-                "previous",
-                "function",
-                "distributor",
-                "index",
-                "autorehash",
-                "pconnect",
-                "retry_interval",
-                "lazy_connect",
-                "connect_timeout",
-            );
-
             $redisArrayOptions = array();
-            foreach ($redisArrayOptionNames as $optionName) {
+            foreach ($this->redisArrayOptionNames as $optionName) {
                 if (array_key_exists($optionName, $options)) {
                     $redisArrayOptions[$optionName] = $options[$optionName];
                 }


### PR DESCRIPTION
in order to properly configure redis arrays, enable pass-through of array options.
