### PR TITLE
prevent mkdir from throwing warnings

### DIFF
--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -239,7 +239,7 @@ class FileSystem implements DriverInterface
 
         if (!file_exists($path)) {
             if (!is_dir(dirname($path))) {
-                if (!mkdir(dirname($path), $this->dirPermissions, true)) {
+                if (!@mkdir(dirname($path), $this->dirPermissions, true)) {
                     return false;
                 }
             }


### PR DESCRIPTION
When using stash with several PHP processes, it happens that though the `if(is_dir())`-statement did not yet see a directory, it exists when you come to the `mkdir()`-statement.

I suppose we could also get rid of the `is_dir()` call completely if `mkdir()` is comparable cheap with already created dir’s (haven’t tested that, yet)