### PR TITLE
Update SqlitePdo.php

### DIFF
--- a/src/Stash/Driver/Sub/SqlitePdo.php
+++ b/src/Stash/Driver/Sub/SqlitePdo.php
@@ -39,7 +39,7 @@ class SqlitePdo extends Sqlite
     /**
      * {@inheritdoc}
      */
-    protected $responseCode = \PDO::FETCH_ASSOC;
+    protected $responseCode;
 
     /**
      * {@inheritdoc}
@@ -56,9 +56,9 @@ class SqlitePdo extends Sqlite
      */
     public static function isAvailable()
     {
-        $drivers = class_exists('\PDO', false) ? \PDO::getAvailableDrivers() : array();
-
-        return in_array(static::$pdoDriver, $drivers);
+        return class_exists('\PDO', false) ?
+            in_array(static::$pdoDriver, \PDO::getAvailableDrivers()) :
+            false;
     }
 
     /**


### PR DESCRIPTION
Assigning \PDO::FETCH_ASSOC to class property definition causes an error if PDO is not installed, triggered by the use of static::$pdoDriver within isAvailable().

Proposed change removes the property assignment (it is set in the constructor anyway) and modifies isAvailable() to just return false if there is no PDO available.
