### PR TITLE
Fix error when PDO is not installed.

### DIFF
--- a/src/Stash/Driver/Sub/SqlitePdo.php
+++ b/src/Stash/Driver/Sub/SqlitePdo.php
@@ -39,7 +39,7 @@ class SqlitePdo extends Sqlite
     /**
      * {@inheritdoc}
      */
-    protected $responseCode = \PDO::FETCH_ASSOC;
+    protected $responseCode;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Assigning \PDO::FETCH_ASSOC to class property definition causes an error if PDO is not installed, triggered by the use of static::$pdoDriver within isAvailable().
