### PR TITLE
Redis driver lazily connects to Redis server

### DIFF
--- a/tests/Stash/Test/Driver/RedisArrayTest.php
+++ b/tests/Stash/Test/Driver/RedisArrayTest.php
@@ -58,9 +58,10 @@ class RedisArrayTest extends RedisTest
     {
         $driver = $this->getFreshDriver();
         $class = new \ReflectionClass($driver);
-        $redisProperty = $class->getProperty('redis');
-        $redisProperty->setAccessible(true);
-        $redisArray = $redisProperty->getValue($driver);
+
+        $redisClient = $class->getMethod('getRedisClient');
+        $redisClient->setAccessible(true);
+        $redisArray = $redisClient->invoke($driver);
 
         $this->assertInstanceOf('\RedisArray', $redisArray);
     }


### PR DESCRIPTION
Instead of instantiating a `\Redis` or `\RedisArray` instance upon instantiation, `\Stash\Driver\Redis` now waits until it tries to use the connection. We do this by inserting a `getRedisClient()` method call into each place that we previously referenced `$this->redis`.

The motivation for this change was to increase the resilience of code to the Redis server being down. Instead of an exception being thrown upon container initialisation the exceptions can be handled on a per-feature basis. When Redis goes down: if the web page doesn't need to pull anything from Redis we are unaffected because we don't try to connect anyway; if a feature does try to use Redis but can exist without it we don't error because the connection exception can be handled locally.

Update: The Redis tests are passing but there is [a failure](https://travis-ci.org/tedious/Stash/jobs/32899659#L142-L147) in `Stash\Test\Driver\MemcachedTest::testClear` when running under HHVM.