### PR TITLE
Reduce function calls in creation of Item classes

### DIFF
--- a/src/Stash/Interfaces/ItemInterface.php
+++ b/src/Stash/Interfaces/ItemInterface.php
@@ -30,7 +30,7 @@ interface ItemInterface
      * @param array       $key
      * @param string|null $namespace
      */
-    public function setKey($key, $namespace = null);
+    public function setKey(array $key, $namespace = null);
 
     /**
      * This disables any IO operations by this object, effectively preventing

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -151,16 +151,27 @@ class Item implements ItemInterface
     public function setPool(PoolInterface $pool)
     {
         $this->pool = $pool;
-        $this->setDriver($pool->getDriver());
+        $this->driver = $pool->getDriver();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setKey($key, $namespace = null)
+    public function setKey(array $key, $namespace = null)
     {
         $this->namespace = $namespace;
-        $this->setupKey($key);
+
+        $keyStringTmp = $key;
+        if (isset($this->namespace)) {
+            array_shift($keyStringTmp);
+        }
+
+        $this->keyString = implode('/', $keyStringTmp);
+
+        // We implant the namespace "cache" to the front of every stash object's key. This allows us to segment
+        // off the user data, and use other 'namespaces' for internal purposes.
+        array_unshift($key, 'cache');
+        $this->key = array_map('strtolower', $key);
     }
 
     /**
@@ -589,31 +600,5 @@ class Item implements ItemInterface
             $spkey[0] = 'sp';
             $this->driver->clear($spkey);
         }
-    }
-
-    /**
-     * This function is used by the Pool object while creating this object. It
-     * is an internal function an should not be called directly.
-     *
-     * @param  array                     $key
-     * @throws \InvalidArgumentException
-     */
-    protected function setupKey($key)
-    {
-        if (!is_array($key)) {
-            throw new \InvalidArgumentException('Item requires keys as arrays.');
-        }
-
-        $keyStringTmp = $key;
-        if (isset($this->namespace)) {
-            array_shift($keyStringTmp);
-        }
-
-        $this->keyString = implode('/', $keyStringTmp);
-
-        // We implant the namespace "cache" to the front of every stash object's key. This allows us to segment
-        // off the user data, and use other 'namespaces' for internal purposes.
-        array_unshift($key, 'cache');
-        $this->key = array_map('strtolower', $key);
     }
 }

--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -103,33 +103,30 @@ class Pool implements PoolInterface
     public function getItem()
     {
         $args = func_get_args();
-        $argCount = count($args);
 
-        if ($argCount < 1) {
+        if (!isset($args[0])) {
             throw new \InvalidArgumentException('Item constructor requires a key.');
         }
 
         // check to see if a single array was used instead of multiple arguments
-        if ($argCount == 1 && is_array($args[0])) {
+        if (!isset($args[1]) && is_array($args[0])) {
             $args = $args[0];
-            $argCount = count($args);
         }
 
-        if ($argCount == 1) {
+        // if only one item treat as key string
+        if (!isset($args[1])) {
             $keyString = trim($args[0], '/');
             $key = explode('/', $keyString);
         } else {
             $key = $args;
         }
 
-        if (!($namespace = $this->getNamespace())) {
-            $namespace = 'stash_default';
-        }
+        $namespace = empty($this->namespace) ? 'stash_default' : $this->namespace;
 
         array_unshift($key, $namespace);
 
         foreach ($key as $node) {
-            if (strlen($node) < 1) {
+            if (!isset($node[1]) && strlen($node) < 1) {
                 throw new \InvalidArgumentException('Invalid or Empty Node passed to getItem constructor.');
             }
         }

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -152,8 +152,8 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Item requires keys as arrays.
+     * @expectedException PHPUnit_Framework_Error
+     * @expectedExceptionMessage Argument 1 passed to Stash\Item::setKey()
      */
     public function testGetItemInvalidKey()
     {


### PR DESCRIPTION
With heavy use of Stash creation of Item classes & setKey shows up
in profile data, so the change tries to reduce function calls in these.

Suggested followup is executeGet().
Note: Might need another pass on this tomorrow for CS / tests if this is otherwise accepted.
Note2: Contains interface change on Item to force array type on $key, felt like a easy way to avoid having to check.