### PR TITLE
checking if (persistent) servers exist before adding servers

### DIFF
--- a/src/Stash/Driver/Sub/Memcached.php
+++ b/src/Stash/Driver/Sub/Memcached.php
@@ -64,7 +64,10 @@ class Memcached
 
         $memcached = new \Memcached();
 
-        $memcached->addServers($servers);
+        $serverList = $memcached->getServerList();
+        if (empty($serverList)) {
+            $memcached->addServers($servers);
+        }
 
         foreach ($options as $name => $value) {
             $name = strtoupper($name);


### PR DESCRIPTION
See Comment:
http://ch1.php.net/manual/de/memcached.addservers.php#102486

When using persistent connections servers are already available when creating new instances of Memcached. Therefore the number of connections is constantly increasing.
