### PR TITLE
Adds PoolTrait

### DIFF
--- a/src/Stash/PoolTrait.php
+++ b/src/Stash/PoolTrait.php
@@ -11,6 +11,7 @@
 
 namespace Stash;
 
+use Stash\Interfaces\PoolInterface;
 use Stash\Interfaces\DriverInterface;
 
 /**

--- a/src/Stash/PoolTrait.php
+++ b/src/Stash/PoolTrait.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash;
+
+use Stash\Interfaces\DriverInterface;
+
+/**
+ *
+ *
+ * @package Stash
+ * @author  Robert Hafner <tedivm@tedivm.com>
+ */
+trait PoolTrait
+{
+    /**
+     * @var PoolInterface
+     */
+    protected $pool;
+
+    /**
+     * Returns the Pool
+     *
+     * @return PoolInterface
+     */
+    public function getPool()
+    {
+        if (!$this->pool) {
+            $this->pool = new Pool;
+        }
+
+        return $this->pool;
+    }
+
+    /**
+     * Sets the Pool
+     *
+     * @param PoolInterface $pool
+     *
+     * @return $this
+     */
+    public function setPool(PoolInterface $pool = null)
+    {
+        $this->pool = $pool;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setItemClass($class)
+    {
+        return $this->getPool()->setItemClass($class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem()
+    {
+        $pool = $this->getPool();
+
+        return call_user_func_array(array($pool, 'getItem'), func_get_args());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItemIterator($keys)
+    {
+        return $this->getPool()->getItemIterator($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush()
+    {
+        return $this->getPool()->flush();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function purge()
+    {
+        return $this->getPool()->purge();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDriver(DriverInterface $driver)
+    {
+        $this->getPool()->setDriver($driver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDriver()
+    {
+        return $this->getPool()->getDriver();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setNamespace($namespace = null)
+    {
+        return $this->getPool()->setNamespace($namespace);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNamespace()
+    {
+        return $this->getPool()->getNamespace();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLogger($logger)
+    {
+        return $this->getPool()->setLogger($logger);
+    }
+}

--- a/tests/Stash/Test/PoolTraitTest.php
+++ b/tests/Stash/Test/PoolTraitTest.php
@@ -24,6 +24,18 @@ class PoolTraitTest extends AbstractPoolTest
 {
     protected $poolClass = '\Stash\Test\Stubs\PoolTraitStub';
 
+    public function testPool()
+    {
+        $decorator = $this->getTestPool();
+
+        $pool = $this->getMock('Stash\Interfaces\PoolInterface');
+
+        $this->assertSame($decorator, $decorator->setPool($pool));
+        $this->assertSame($pool, $decorator->getPool());
+        $decorator->setPool();
+        $this->assertInstanceOf('Stash\Interfaces\PoolInterface', $decorator->getPool());
+    }
+
     public function testSetItemClass()
     {
         $mockItem = $this->getMock('Stash\Interfaces\ItemInterface');

--- a/tests/Stash/Test/PoolTraitTest.php
+++ b/tests/Stash/Test/PoolTraitTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash\Test;
+
+use Stash\Test\Stubs\LoggerStub;
+use Stash\Test\Stubs\DriverExceptionStub;
+
+/**
+ * @package Stash
+ * @author  Robert Hafner <tedivm@tedivm.com>
+ *
+ * @requires PHP 5.4
+ */
+class PoolTraitTest extends AbstractPoolTest
+{
+    protected $poolClass = '\Stash\Test\Stubs\PoolTraitStub';
+
+    public function testSetItemClass()
+    {
+        $mockItem = $this->getMock('Stash\Interfaces\ItemInterface');
+        $mockClassName = get_class($mockItem);
+        $pool = $this->getTestPool();
+
+        $this->assertTrue($pool->setItemClass($mockClassName));
+        $this->assertAttributeEquals($mockClassName, 'itemClass', $pool->getPool());
+    }
+
+    public function testNamespacing()
+    {
+        $pool = $this->getTestPool();
+
+        $this->assertAttributeEquals(null, 'namespace', $pool->getPool(), 'Namespace starts empty.');
+        $this->assertTrue($pool->setNamespace('TestSpace'), 'setNamespace returns true.');
+        $this->assertAttributeEquals('TestSpace', 'namespace', $pool->getPool(), 'setNamespace sets the namespace.');
+        $this->assertEquals('TestSpace', $pool->getNamespace(), 'getNamespace returns current namespace.');
+
+        $this->assertTrue($pool->setNamespace(), 'setNamespace returns true when setting null.');
+        $this->assertAttributeEquals(null, 'namespace', $pool->getPool(), 'setNamespace() empties namespace.');
+        $this->assertFalse($pool->getNamespace(), 'getNamespace returns false when no namespace is set.');
+    }
+
+    public function testSetLogger()
+    {
+        $pool = $this->getTestPool();
+
+        $driver = new DriverExceptionStub();
+        $pool->setDriver($driver);
+
+        $logger = new LoggerStub();
+        $pool->setLogger($logger);
+
+        $this->assertAttributeInstanceOf('Stash\Test\Stubs\LoggerStub', 'logger', $pool->getPool(), 'setLogger injects logger into Item.');
+    }
+}

--- a/tests/Stash/Test/Stubs/PoolTraitStub.php
+++ b/tests/Stash/Test/Stubs/PoolTraitStub.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash\Test\Stubs;
+
+use Stash;
+
+/**
+ * PoolTraitStub is used to test that PoolTrait can be used on any objects.
+ *
+ * @package Stash
+ * @author  Robert Hafner <tedivm@tedivm.com>
+ *
+ * @codeCoverageIgnore
+ */
+class PoolTraitStub
+{
+    use \Stash\PoolTrait;
+}


### PR DESCRIPTION
After rereading the issue maybe I was not clear, but I will be now: the trait implements all functions from the interface, meaning it can be used as a decorator with an appropriate class implementing the required interface.

Some of the tests checked directly the attribute of the class, those were rewritten. Other than that it uses the same tests as Pool does.

Should I add any documentation?

Solves #184 
