### PR TITLE
Refactored SqlitePDO::isAvailable

### DIFF
--- a/src/Stash/Driver/Sub/SqlitePdo.php
+++ b/src/Stash/Driver/Sub/SqlitePdo.php
@@ -56,7 +56,11 @@ class SqlitePdo extends Sqlite
      */
     public static function isAvailable()
     {
-        $drivers = class_exists('\PDO', false) ? \PDO::getAvailableDrivers() : array();
+        if (!class_exists('\PDO', false)) {
+            return false;
+        }
+
+        $drivers = \PDO::getAvailableDrivers();
 
         return in_array(static::$pdoDriver, $drivers);
     }


### PR DESCRIPTION
This prevents errors when PDO constants aren’t available. This solves #178 while still allowing a default value to be set.
