### PR TITLE
Add CLIENT_MODE option

### DIFF
--- a/src/Stash/Driver/Sub/Memcached.php
+++ b/src/Stash/Driver/Sub/Memcached.php
@@ -59,7 +59,8 @@ class Memcached
                             'RECV_TIMEOUT',
                             'POLL_TIMEOUT',
                             'CACHE_LOOKUPS',
-                            'SERVER_FAILURE_LIMIT'
+                            'SERVER_FAILURE_LIMIT',
+                            'CLIENT_MODE'
         );
 
         $memcached = new \Memcached();


### PR DESCRIPTION
AWS have a special memcached client that allows for autodiscovery. It
has an extra option OPT_CLIENT_MODE.

See: http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html

Because the option handling code checks that the option is actually defined before
setting it, adding this option causes no issues for non AWS clients
