### PR TITLE
Simpler null/missing value distinction during file read

### DIFF
--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -210,16 +210,10 @@ class FileSystem implements DriverInterface
             $expiration = null;
         }
 
-        // If the item does not exist we should return false. However, it's
-        // possible that the item exists as null, so we have to make sure that
-        // it's both unset and not null. The downside to this is that the
-        // is_null function will issue a warning on an item that isn't set.
-        // So we're stuck testing and suppressing the warning.
-        if (!isset($data) || @is_null($data)) {
-            return array('data' => null, 'expiration' => $expiration);
-        } else {
-            return array('data' => $data, 'expiration' => $expiration);
+        if (!isset($data)) {
+            $data = null;
         }
+        return array('data' => $data, 'expiration' => $expiration);
     }
 
     /**


### PR DESCRIPTION
Whether $data === null or not set this will work.
