### PR TITLE
Modified APC to deal with HHVM bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,5 @@ services:
   - memcached
 
 matrix:
-    allow_failures:
-      - php: hhvm
+    allow_failures: 
       - php: hhvm-nightly


### PR DESCRIPTION
The APCIterator in HHVM does not always return every result, so we work around this by creating a loop that generates new iterators until all of the items are cleared.
