### PR TITLE
Added additional directory cleanup functionality

### DIFF
--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -417,7 +417,7 @@ class FileSystem implements DriverInterface
         }
 
         if (is_dir($path)) {
-            return Utilities::deleteRecursive($path);
+            return Utilities::deleteRecursive($path, true);
         }
 
         return isset($return);

--- a/tests/Stash/Test/UtilitiesTest.php
+++ b/tests/Stash/Test/UtilitiesTest.php
@@ -106,5 +106,17 @@ class UtilitiesTest extends \PHPUnit_Framework_TestCase
         $this->assertFileNotExists($tmp, 'deleteRecursive cleared out the directory');
 
         $this->assertFalse(Utilities::deleteRecursive($tmp), 'deleteRecursive returned false when passed nonexistant directory');
+
+        $tmp = sys_get_temp_dir() . '/stash/test/';
+        $dirOne = $tmp . '/Test1';
+        @mkdir($dirOne, 0770, true);
+        $dirTwo = $tmp . '/Test2';
+        @mkdir($dirTwo, 0770, true);
+
+        Utilities::deleteRecursive($dirOne, true);
+        $this->assertFileExists($dirTwo, 'deleteRecursive does not erase sibling directories.');
+
+        Utilities::deleteRecursive($dirTwo, true);
+        $this->assertFileNotExists($tmp, 'deleteRecursive cleared out the empty parent directory');
     }
 }


### PR DESCRIPTION
This is an attempt to resolve #186. It makes sure that empty directories get pruned along with the items inside of them during a cache clear. If an item is the last one to be removed from a directory this will run some tests and then clean that directory up.
