### PR TITLE
Remove obsolete case / dead code.

### DIFF
--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -542,7 +542,6 @@ class Item implements ItemInterface
                 break;
 
             default:
-            case Invalidation::NONE:
                 $this->isHit = false;
                 break;
         } // switch($invalidate)


### PR DESCRIPTION
This code can never be reached because of an earlier return when the
invalidation is `Invalidation::NONE`.

see https://github.com/Jimdo/Stash/blob/6ca8bcc2e2dd9a85ce7a225057ca1ea97e333fe1/src/Stash/Item.php#L500-L504