### PR TITLE
Added php 7 testing to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
     - 5.4
     - 5.5
     - 5.6
+    - 7.0
     - hhvm
     - hhvm-nightly
 
@@ -26,3 +27,4 @@ matrix:
     fast_finish: true
     allow_failures:
       - php: hhvm-nightly
+      - php: 7.0

--- a/tests/travis/php_setup.sh
+++ b/tests/travis/php_setup.sh
@@ -9,7 +9,7 @@ echo "**************************"
 echo ""
 echo "PHP Version: $TRAVIS_PHP_VERSION"
 
-if [ "$TRAVIS_PHP_VERSION" = "hhvm" ] || [ "$TRAVIS_PHP_VERSION" = "hhvm-nightly" ]; then
+if [ "$TRAVIS_PHP_VERSION" = "hhvm" ] || [ "$TRAVIS_PHP_VERSION" = "hhvm-nightly" ] || [ "$TRAVIS_PHP_VERSION" = "7.0" ]; then
     echo "Unable to install php extensions on current system"
 
 else


### PR DESCRIPTION
This is added in allowing failures (although it currently passes), as php7 is stlll pre-alpha.