### PR TITLE
Added an AbstractDriver class for shared driver functionality.

### DIFF
--- a/src/Stash/Driver/AbstractDriver.php
+++ b/src/Stash/Driver/AbstractDriver.php
@@ -25,6 +25,9 @@ abstract class AbstractDriver implements DriverInterface
     /**
      * Initializes the driver.
      *
+     * @param array $options
+     *   An additional array of options to pass through to setOptions().
+     *
      * @throws RuntimeException
      */
     public function __construct(array $options = array())

--- a/src/Stash/Driver/AbstractDriver.php
+++ b/src/Stash/Driver/AbstractDriver.php
@@ -35,7 +35,9 @@ abstract class AbstractDriver implements DriverInterface
         if (!static::isAvailable()) {
             throw new RuntimeException(__CLASS__ . ' is not available.');
         }
-        $this->setOptions($options);
+        if (!empty($options)) {
+            $this->setOptions($options);
+        }
     }
 
     /**

--- a/src/Stash/Driver/AbstractDriver.php
+++ b/src/Stash/Driver/AbstractDriver.php
@@ -11,6 +11,8 @@
 
 namespace Stash\Driver;
 
+use Stash\Interfaces\DriverInterface;
+
 /**
  * Abstract base class for all drivers to use.
  *

--- a/src/Stash/Driver/AbstractDriver.php
+++ b/src/Stash/Driver/AbstractDriver.php
@@ -36,11 +36,7 @@ abstract class AbstractDriver implements DriverInterface
             throw new RuntimeException(__CLASS__ . ' is not available.');
         }
 
-        // Call setOptions() if there are any options to set.
-        $options += $this->getDefaultOptions();
-        if (!empty($options)) {
-            $this->setOptions($options);
-        }
+        $this->setOptions($options);
     }
 
     /**

--- a/src/Stash/Driver/AbstractDriver.php
+++ b/src/Stash/Driver/AbstractDriver.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash\Driver;
+
+/**
+ * Abstract base class for all drivers to use.
+ *
+ * @package Stash
+ * @author  Robert Hafner <tedivm@tedivm.com>
+ */
+abstract class AbstractDriver implements DriverInterface
+{
+    /**
+     * Initializes the driver.
+     *
+     * @throws RuntimeException
+     */
+    public function __construct(array $options = array())
+    {
+        if (!static::isAvailable()) {
+            throw new RuntimeException(__CLASS__ . ' is not available.');
+        }
+        $this->setOptions($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOptions(array $options = array())
+    {
+        // empty
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function isAvailable()
+    {
+        return true;
+    }
+}

--- a/src/Stash/Driver/AbstractDriver.php
+++ b/src/Stash/Driver/AbstractDriver.php
@@ -35,9 +35,19 @@ abstract class AbstractDriver implements DriverInterface
         if (!static::isAvailable()) {
             throw new RuntimeException(__CLASS__ . ' is not available.');
         }
+
+        // Call setOptions() if there are any options to set.
+        $options += $this->getDefaultOptions();
         if (!empty($options)) {
             $this->setOptions($options);
         }
+    }
+
+    /**
+     * @return array
+     */
+    public function getDefaultOptions() {
+        return array();
     }
 
     /**

--- a/src/Stash/Driver/AbstractDriver.php
+++ b/src/Stash/Driver/AbstractDriver.php
@@ -12,6 +12,7 @@
 namespace Stash\Driver;
 
 use Stash\Interfaces\DriverInterface;
+use Stash\Exception\RuntimeException;
 
 /**
  * Abstract base class for all drivers to use.

--- a/src/Stash/Driver/AbstractDriver.php
+++ b/src/Stash/Driver/AbstractDriver.php
@@ -42,7 +42,8 @@ abstract class AbstractDriver implements DriverInterface
     /**
      * @return array
      */
-    public function getDefaultOptions() {
+    public function getDefaultOptions()
+    {
         return array();
     }
 

--- a/src/Stash/Driver/Apc.php
+++ b/src/Stash/Driver/Apc.php
@@ -13,7 +13,6 @@ namespace Stash\Driver;
 
 use Stash;
 use Stash\Exception\RuntimeException;
-use Stash\Interfaces\DriverInterface;
 
 /**
  * The APC driver is a wrapper for the APC extension, which allows developers to store data in memory.

--- a/src/Stash/Driver/Apc.php
+++ b/src/Stash/Driver/Apc.php
@@ -46,14 +46,12 @@ class Apc extends AbstractDriver
     /**
      * {@inheritdoc}
      */
-    public function __construct(array $options = array())
+    public function getDefaultOptions()
     {
-        // Provide default options.
-        $options += array(
+        return array(
             'ttl' => 300,
             'namespace' => md5(__FILE__),
         );
-        parent::__construct($options);
     }
 
     /**
@@ -66,6 +64,8 @@ class Apc extends AbstractDriver
      */
     public function setOptions(array $options = array())
     {
+        $options += $this->getDefaultOptions();
+
         $this->ttl = (int) $options['ttl'];
         $this->apcNamespace = $options['namespace'];
     }

--- a/src/Stash/Driver/Apc.php
+++ b/src/Stash/Driver/Apc.php
@@ -44,21 +44,33 @@ class Apc extends AbstractDriver
     protected $chunkSize = 100;
 
     /**
+     * {@inheritdoc}
+     */
+    public function __construct(array $options = array())
+    {
+        // Provide default options.
+        $options += array(
+            'namespace' => md5(__FILE__),
+        );
+        parent::__construct($options);
+    }
+
+    /**
      * This function should takes an array which is used to pass option values to the driver.
      *
      * * ttl - This is the maximum time the item will be stored.
      * * namespace - This should be used when multiple projects may use the same library.
      *
-     * @param  array                             $options
-     * @throws \Stash\Exception\RuntimeException
+     * @param array $options
      */
     public function setOptions(array $options = array())
     {
         if (isset($options['ttl']) && is_numeric($options['ttl'])) {
             $this->ttl = (int) $options['ttl'];
         }
-
-        $this->apcNamespace = isset($options['namespace']) ? $options['namespace'] : md5(__FILE__);
+        if (isset($options['namespace'])) {
+            $this->apcNamespace = $options['namespace'];
+        }
     }
 
     /**

--- a/src/Stash/Driver/Apc.php
+++ b/src/Stash/Driver/Apc.php
@@ -21,7 +21,7 @@ use Stash\Interfaces\DriverInterface;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class Apc implements DriverInterface
+class Apc extends AbstractDriver
 {
     /**
      * Default maximum time an Item will be stored.
@@ -46,18 +46,6 @@ class Apc implements DriverInterface
     protected $chunkSize = 100;
 
     /**
-     * Initializes the driver.
-     *
-     * @throws RuntimeException 'Extension is not installed.'
-     */
-    public function __construct()
-    {
-        if (!static::isAvailable()) {
-            throw new RuntimeException('Extension is not installed.');
-        }
-    }
-
-    /**
      * This function should takes an array which is used to pass option values to the driver.
      *
      * * ttl - This is the maximum time the item will be stored.
@@ -73,13 +61,6 @@ class Apc implements DriverInterface
         }
 
         $this->apcNamespace = isset($options['namespace']) ? $options['namespace'] : md5(__FILE__);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __destruct()
-    {
     }
 
     /**

--- a/src/Stash/Driver/Apc.php
+++ b/src/Stash/Driver/Apc.php
@@ -26,7 +26,7 @@ class Apc extends AbstractDriver
      *
      * @var int
      */
-    protected $ttl = 300;
+    protected $ttl;
 
     /**
      * This is an install specific namespace used to segment different applications from interacting with each other
@@ -50,6 +50,7 @@ class Apc extends AbstractDriver
     {
         // Provide default options.
         $options += array(
+            'ttl' => 300,
             'namespace' => md5(__FILE__),
         );
         parent::__construct($options);
@@ -65,12 +66,8 @@ class Apc extends AbstractDriver
      */
     public function setOptions(array $options = array())
     {
-        if (isset($options['ttl']) && is_numeric($options['ttl'])) {
-            $this->ttl = (int) $options['ttl'];
-        }
-        if (isset($options['namespace'])) {
-            $this->apcNamespace = $options['namespace'];
-        }
+        $this->ttl = (int) $options['ttl'];
+        $this->apcNamespace = $options['namespace'];
     }
 
     /**

--- a/src/Stash/Driver/Apc.php
+++ b/src/Stash/Driver/Apc.php
@@ -12,7 +12,6 @@
 namespace Stash\Driver;
 
 use Stash;
-use Stash\Exception\RuntimeException;
 
 /**
  * The APC driver is a wrapper for the APC extension, which allows developers to store data in memory.

--- a/src/Stash/Driver/BlackHole.php
+++ b/src/Stash/Driver/BlackHole.php
@@ -11,8 +11,6 @@
 
 namespace Stash\Driver;
 
-use Stash\Interfaces\DriverInterface;
-
 /**
  * This class provides a NULL caching driver, it always takes values, but never saves them
  * Can be used as an default save driver

--- a/src/Stash/Driver/BlackHole.php
+++ b/src/Stash/Driver/BlackHole.php
@@ -19,16 +19,8 @@ use Stash\Interfaces\DriverInterface;
  *
  * @author Benjamin Zikarsky <benjamin.zikarsky@perbility.de>
  */
-class BlackHole implements DriverInterface
+class BlackHole extends AbstractDriver
 {
-    /**
-     * NOOP constructor
-     */
-    public function setOptions(array $options = array())
-    {
-        // empty
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -57,14 +49,6 @@ class BlackHole implements DriverInterface
      * {@inheritdoc}
      */
     public function storeData($key, $data, $expiration)
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function isAvailable()
     {
         return true;
     }

--- a/src/Stash/Driver/Composite.php
+++ b/src/Stash/Driver/Composite.php
@@ -13,6 +13,7 @@ namespace Stash\Driver;
 
 use Stash;
 use Stash\Exception\RuntimeException;
+use Stash\Interfaces\DriverInterface;
 
 /**
  * Composite is a wrapper around one or more StashDrivers, allowing faster caching engines with size or

--- a/src/Stash/Driver/Composite.php
+++ b/src/Stash/Driver/Composite.php
@@ -41,6 +41,8 @@ class Composite extends AbstractDriver
      */
     public function setOptions(array $options = array())
     {
+        $options += $this->getDefaultOptions();
+
         if (!isset($options['drivers']) || !is_array($options['drivers']) || count($options['drivers']) < 1) {
             throw new RuntimeException('One or more secondary drivers are required.');
         }

--- a/src/Stash/Driver/Composite.php
+++ b/src/Stash/Driver/Composite.php
@@ -43,20 +43,22 @@ class Composite extends AbstractDriver
     {
         $options += $this->getDefaultOptions();
 
-        if (!isset($options['drivers']) || !is_array($options['drivers']) || count($options['drivers']) < 1) {
-            throw new RuntimeException('One or more secondary drivers are required.');
-        }
+        if (isset($options['drivers'])) {
+            if (count($options['drivers']) < 1) {
+                throw new RuntimeException('One or more secondary drivers are required.');
+            }
+            $this->drivers = array();
 
-        foreach ($options['drivers'] as $driver) {
-            if (!(is_object($driver) && $driver instanceof DriverInterface)) {
-                continue;
+            foreach ($options['drivers'] as $driver) {
+                if (!(is_object($driver) && $driver instanceof DriverInterface)) {
+                    continue;
+                }
+                $this->drivers[] = $driver;
             }
 
-            $this->drivers[] = $driver;
-        }
-
-        if (count($this->drivers) < 1) {
-            throw new RuntimeException('None of the secondary drivers can be enabled.');
+            if (count($this->drivers) < 1) {
+                throw new RuntimeException('None of the secondary drivers can be enabled.');
+            }
         }
     }
 

--- a/src/Stash/Driver/Composite.php
+++ b/src/Stash/Driver/Composite.php
@@ -23,7 +23,7 @@ use Stash\Interfaces\DriverInterface;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class Composite implements DriverInterface
+class Composite extends AbstractDriver
 {
     /**
      * The drivers this driver encapsulates.
@@ -56,13 +56,6 @@ class Composite implements DriverInterface
         if (count($this->drivers) < 1) {
             throw new RuntimeException('None of the secondary drivers can be enabled.');
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __destruct()
-    {
     }
 
     /**
@@ -155,17 +148,5 @@ class Composite implements DriverInterface
         }
 
         return $return;
-    }
-
-    /**
-     * This function checks to see if this driver is available. This always returns true because this
-     * driver has no dependencies, being a wrapper around other classes.
-     *
-     * {@inheritdoc}
-     * @return bool true
-     */
-    public static function isAvailable()
-    {
-        return true;
     }
 }

--- a/src/Stash/Driver/Composite.php
+++ b/src/Stash/Driver/Composite.php
@@ -13,7 +13,6 @@ namespace Stash\Driver;
 
 use Stash;
 use Stash\Exception\RuntimeException;
-use Stash\Interfaces\DriverInterface;
 
 /**
  * Composite is a wrapper around one or more StashDrivers, allowing faster caching engines with size or

--- a/src/Stash/Driver/Ephemeral.php
+++ b/src/Stash/Driver/Ephemeral.php
@@ -21,7 +21,7 @@ use Stash\Interfaces\DriverInterface;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class Ephemeral implements DriverInterface
+class Ephemeral extends AbstractDriver
 {
     /**
      * Contains the cached data.
@@ -29,22 +29,6 @@ class Ephemeral implements DriverInterface
      * @var array
      */
     protected $store = array();
-
-    /**
-     * Has no options.
-     *
-     * @param array $options
-     */
-    public function setOptions(array $options = array())
-    {
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __destruct()
-    {
-    }
 
     /**
      * {@inheritdoc}
@@ -113,18 +97,6 @@ class Ephemeral implements DriverInterface
             }
         }
 
-        return true;
-    }
-
-    /**
-     * This function checks to see if this driver is available. This always returns true because this
-     * driver has no dependencies, begin a wrapper around other classes.
-     *
-     * {@inheritdoc}
-     * @return bool true
-     */
-    public static function isAvailable()
-    {
         return true;
     }
 }

--- a/src/Stash/Driver/Ephemeral.php
+++ b/src/Stash/Driver/Ephemeral.php
@@ -12,7 +12,6 @@
 namespace Stash\Driver;
 
 use Stash;
-use Stash\Interfaces\DriverInterface;
 
 /**
  * The ephemeral class exists to assist with testing the main Stash class. Since this is a very minimal driver we can

--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -27,7 +27,7 @@ use Stash\Interfaces\DriverInterface;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class FileSystem implements DriverInterface
+class FileSystem extends AbstractDriver
 {
     /**
      * This is the path to the file which will be used to store the cached item. It is based off of the key.
@@ -175,13 +175,6 @@ class FileSystem implements DriverInterface
         }
 
         Utilities::checkFileSystemPermissions($this->cachePath, $this->dirPermissions);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __destruct()
-    {
     }
 
     /**
@@ -400,17 +393,5 @@ class FileSystem implements DriverInterface
         }
 
         return $this->encoder;
-    }
-
-    /**
-     * This function checks to see if it is possible to enable this driver. This returns true no matter what, since
-     * there is typically a filesystem available somewhere.
-     *
-     * {@inheritdoc}
-     * @return bool true
-     */
-    public static function isAvailable()
-    {
-        return true;
     }
 }

--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -134,33 +134,16 @@ class FileSystem extends AbstractDriver
      */
     public function setOptions(array $options = array())
     {
-        if (isset($options['path'])) {
-            $this->cachePath = rtrim($options['path'], '\\/') . DIRECTORY_SEPARATOR;
-        }
-        if (isset($options['filePermissions'])) {
-            $this->filePermissions = $options['filePermissions'];
-        }
-        if (isset($options['dirPermissions'])) {
-            $this->dirPermissions = $options['dirPermissions'];
-        }
-        if (isset($options['dirSplit'])) {
-            if (!is_numeric($options['dirSplit']) || $options['dirSplit'] < 1) {
-                $options['dirSplit'] = 1;
-            }
-            $this->directorySplit = (int) $options['dirSplit'];
-        }
-        if (isset($options['memKeyLimit'])) {
-            if (!is_numeric($options['memKeyLimit']) || $options['memKeyLimit'] < 1) {
-                $options['memKeyLimit'] = 0;
-            }
-            $this->memStoreLimit = (int) $options['memKeyLimit'];
-        }
-        if (isset($options['keyHashFunction'])) {
-            if (is_callable($options['keyHashFunction'])) {
-                $this->keyHashFunction = $options['keyHashFunction'];
-            } else {
-                throw new RuntimeException('Key Hash Function is not callable');
-            }
+        $this->cachePath = rtrim($options['path'], '\\/') . DIRECTORY_SEPARATOR;
+        $this->filePermissions = $options['filePermissions'];
+        $this->dirPermissions = $options['dirPermissions'];
+        $this->directorySplit = max((int) $options['dirSplit'], 1);
+        $this->memStoreLimit = max((int) $options['memKeyLimit'], 0);
+
+        if (is_callable($options['keyHashFunction'])) {
+            $this->keyHashFunction = $options['keyHashFunction'];
+        } else {
+            throw new RuntimeException('Key Hash Function is not callable');
         }
 
         if (isset($options['encoder'])) {

--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -104,55 +104,64 @@ class FileSystem extends AbstractDriver
     protected $disabled = false;
 
     /**
-     * Default values for selections the user does not make.
-     *
-     * @var array
-     */
-    protected $defaultOptions = array('filePermissions' => 0660,
-                                      'dirPermissions' => 0770,
-                                      'dirSplit' => 2,
-                                      'memKeyLimit' => 20,
-                                      'keyHashFunction' => 'md5'
-    );
-
-    /**
      * @var \Stash\Driver\FileSystem\EncoderInterface
      */
     protected $encoder;
 
     /**
+     * {@inheritdoc}
+     */
+    public function __construct(array $options = array())
+    {
+        // Provide default options.
+        $options += array(
+            'path' => Utilities::getBaseDirectory($this),
+            'filePermissions' => 0660,
+            'dirPermissions' => 0770,
+            'dirSplit' => 2,
+            'memKeyLimit' => 20,
+            'keyHashFunction' => 'md5',
+        );
+        parent::__construct($options);
+    }
+
+    /**
      * Requests a list of options.
      *
-     * @param  array                             $options
+     * @param array $options
+     *
      * @throws \Stash\Exception\RuntimeException
      */
     public function setOptions(array $options = array())
     {
-        $options = array_merge($this->defaultOptions, $options);
-
-        $this->cachePath = isset($options['path']) ? $options['path'] : Utilities::getBaseDirectory($this);
-        $this->cachePath = rtrim($this->cachePath, '\\/') . DIRECTORY_SEPARATOR;
-
-        $this->filePermissions = $options['filePermissions'];
-        $this->dirPermissions = $options['dirPermissions'];
-
-        if (!is_numeric($options['dirSplit']) || $options['dirSplit'] < 1) {
-            $options['dirSplit'] = 1;
+        if (isset($options['path'])) {
+            $this->cachePath = rtrim($options['path'], '\\/') . DIRECTORY_SEPARATOR;
         }
-
-        $this->directorySplit = (int) $options['dirSplit'];
-
-        if (!is_numeric($options['memKeyLimit']) || $options['memKeyLimit'] < 1) {
-            $options['memKeyLimit'] = 0;
+        if (isset($options['filePermissions'])) {
+            $this->filePermissions = $options['filePermissions'];
         }
-
-        if (is_callable($options['keyHashFunction'])) {
-            $this->keyHashFunction = $options['keyHashFunction'];
-        } else {
-            throw new RuntimeException('Key Hash Function is not callable');
+        if (isset($options['dirPermissions'])) {
+            $this->dirPermissions = $options['dirPermissions'];
         }
-
-        $this->memStoreLimit = (int) $options['memKeyLimit'];
+        if (isset($options['dirSplit'])) {
+            if (!is_numeric($options['dirSplit']) || $options['dirSplit'] < 1) {
+                $options['dirSplit'] = 1;
+            }
+            $this->directorySplit = (int) $options['dirSplit'];
+        }
+        if (isset($options['memKeyLimit'])) {
+            if (!is_numeric($options['memKeyLimit']) || $options['memKeyLimit'] < 1) {
+                $options['memKeyLimit'] = 0;
+            }
+            $this->memStoreLimit = (int) $options['memKeyLimit'];
+        }
+        if (isset($options['keyHashFunction'])) {
+            if (is_callable($options['keyHashFunction'])) {
+                $this->keyHashFunction = $options['keyHashFunction'];
+            } else {
+                throw new RuntimeException('Key Hash Function is not callable');
+            }
+        }
 
         if (isset($options['encoder'])) {
             $encoder = $options['encoder'];

--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -17,7 +17,6 @@ use Stash\Driver\FileSystem\EncoderInterface;
 use Stash\Utilities;
 use Stash\Exception\LogicException;
 use Stash\Exception\RuntimeException;
-use Stash\Interfaces\DriverInterface;
 
 /**
  * StashFileSystem stores cache objects in the filesystem as native php, making the process of retrieving stored data

--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -111,10 +111,9 @@ class FileSystem extends AbstractDriver
     /**
      * {@inheritdoc}
      */
-    public function __construct(array $options = array())
+    public function getDefaultOptions()
     {
-        // Provide default options.
-        $options += array(
+        return array(
             'path' => Utilities::getBaseDirectory($this),
             'filePermissions' => 0660,
             'dirPermissions' => 0770,
@@ -122,7 +121,6 @@ class FileSystem extends AbstractDriver
             'memKeyLimit' => 20,
             'keyHashFunction' => 'md5',
         );
-        parent::__construct($options);
     }
 
     /**
@@ -134,6 +132,8 @@ class FileSystem extends AbstractDriver
      */
     public function setOptions(array $options = array())
     {
+        $options += $this->getDefaultOptions();
+
         $this->cachePath = rtrim($options['path'], '\\/') . DIRECTORY_SEPARATOR;
         $this->filePermissions = $options['filePermissions'];
         $this->dirPermissions = $options['dirPermissions'];

--- a/src/Stash/Driver/Memcache.php
+++ b/src/Stash/Driver/Memcache.php
@@ -54,6 +54,18 @@ class Memcache extends AbstractDriver
     protected $keyCacheTimeLimit = 1;
 
     /**
+     * {@inheritdoc}
+     */
+    public function __construct(array $options = array())
+    {
+        // Provide default options.
+        $options += array(
+            'keycache_limit' => 1,
+        );
+        parent::__construct($options);
+    }
+
+    /**
      *
      * * servers - An array of servers, with each server represented by its own array (array(host, port, [weight])). If
      * not passed the default is array('127.0.0.1', 11211).
@@ -82,9 +94,7 @@ class Memcache extends AbstractDriver
             $options['extension'] = 'any';
         }
 
-        if (isset($options['keycache_limit']) && is_numeric($options['keycache_limit'])) {
-            $this->keyCacheTimeLimit = $options['keycache_limit'];
-        }
+        $this->keyCacheTimeLimit = (int) $options['keycache_limit'];
 
         $extension = strtolower($options['extension']);
 

--- a/src/Stash/Driver/Memcache.php
+++ b/src/Stash/Driver/Memcache.php
@@ -15,7 +15,6 @@ use Stash;
 use Stash\Exception\RuntimeException;
 use Stash\Driver\Sub\Memcache as SubMemcache;
 use Stash\Driver\Sub\Memcached as SubMemcached;
-use Stash\Interfaces\DriverInterface;
 
 /**
  * Memcache is a wrapper around the popular memcache server. Memcache supports both memcache php

--- a/src/Stash/Driver/Memcache.php
+++ b/src/Stash/Driver/Memcache.php
@@ -56,13 +56,11 @@ class Memcache extends AbstractDriver
     /**
      * {@inheritdoc}
      */
-    public function __construct(array $options = array())
+    public function getDefaultOptions()
     {
-        // Provide default options.
-        $options += array(
+        return array(
             'keycache_limit' => 1,
         );
-        parent::__construct($options);
     }
 
     /**
@@ -85,6 +83,8 @@ class Memcache extends AbstractDriver
      */
     public function setOptions(array $options = array())
     {
+        $options += $this->getDefaultOptions();
+
         if (!isset($options['servers'])) {
             $options['servers'] = array('127.0.0.1', 11211);
         }

--- a/src/Stash/Driver/Memcache.php
+++ b/src/Stash/Driver/Memcache.php
@@ -24,7 +24,7 @@ use Stash\Interfaces\DriverInterface;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class Memcache implements DriverInterface
+class Memcache extends AbstractDriver
 {
     /**
      * Memcache subdriver used by this class.
@@ -53,18 +53,6 @@ class Memcache implements DriverInterface
      * @var int seconds
      */
     protected $keyCacheTimeLimit = 1;
-
-    /**
-     * Initializes the driver.
-     *
-     * @throws RuntimeException 'Extension is not installed.'
-     */
-    public function __construct()
-    {
-        if (!static::isAvailable()) {
-            throw new RuntimeException('Extension is not installed.');
-        }
-    }
 
     /**
      *
@@ -142,13 +130,6 @@ class Memcache implements DriverInterface
         }
 
         return $normalizedServers;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __destruct()
-    {
     }
 
     /**

--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -12,7 +12,6 @@
 namespace Stash\Driver;
 
 use Stash;
-use Stash\Exception\RuntimeException;
 
 /**
  * The Redis driver is used for storing data on a Redis system. This class uses

--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -23,13 +23,6 @@ use Stash;
 class Redis extends AbstractDriver
 {
     /**
-     * An array of default options.
-     *
-     * @var array
-     */
-    protected $defaultOptions = array();
-
-    /**
      * The Redis drivers.
      *
      * @var \Redis|\RedisArray
@@ -66,15 +59,10 @@ class Redis extends AbstractDriver
      *
      * The "password" option is used for clusters which required authentication.
      *
-     * @param  array             $options
-     * @throws \RuntimeException
+     * @param array $options
      */
     public function setOptions(array $options = array())
     {
-        if (!self::isAvailable()) {
-            throw new \RuntimeException('Unable to load Redis driver without PhpRedis extension.');
-        }
-
         // Normalize Server Options
         if (isset($options['servers'])) {
             $unprocessedServers = (is_array($options['servers']))
@@ -114,9 +102,6 @@ class Redis extends AbstractDriver
         } else {
             $servers = array(array('server' => '127.0.0.1', 'port' => '6379', 'ttl' => 0.1));
         }
-
-        // Merge in default values.
-        $options = array_merge($this->defaultOptions, $options);
 
         // this will have to be revisited to support multiple servers, using
         // the RedisArray object. That object acts as a proxy object, meaning

--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -12,7 +12,6 @@
 namespace Stash\Driver;
 
 use Stash;
-use Stash\Interfaces\DriverInterface;
 use Stash\Exception\RuntimeException;
 
 /**

--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -63,6 +63,8 @@ class Redis extends AbstractDriver
      */
     public function setOptions(array $options = array())
     {
+        $options += $this->getDefaultOptions();
+
         // Normalize Server Options
         if (isset($options['servers'])) {
             $unprocessedServers = (is_array($options['servers']))

--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -22,7 +22,7 @@ use Stash\Exception\RuntimeException;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class Redis implements DriverInterface
+class Redis extends AbstractDriver
 {
     /**
      * An array of default options.
@@ -56,18 +56,6 @@ class Redis implements DriverInterface
         "lazy_connect",
         "connect_timeout",
     );
-
-    /**
-     * Initializes the driver.
-     *
-     * @throws RuntimeException 'Extension is not installed.'
-     */
-    public function __construct()
-    {
-        if (!static::isAvailable()) {
-            throw new RuntimeException('Extension is not installed.');
-        }
-    }
 
     /**
      * The options array should contain an array of servers,
@@ -185,8 +173,6 @@ class Redis implements DriverInterface
 
     /**
      * Properly close the connection.
-     *
-     * {@inheritdoc}
      */
     public function __destruct()
     {

--- a/src/Stash/Driver/Sqlite.php
+++ b/src/Stash/Driver/Sqlite.php
@@ -38,10 +38,9 @@ class Sqlite extends AbstractDriver
     /**
      * {@inheritdoc}
      */
-    public function __construct(array $options = array())
+    public function getDefaultOptions()
     {
-        // Provide default options.
-        $options += array(
+        return array(
             'path' => Utilities::getBaseDirectory($this),
             'filePermissions' => 0660,
             'dirPermissions' => 0770,
@@ -49,7 +48,6 @@ class Sqlite extends AbstractDriver
             'nesting' => 0,
             'subdriver' => 'PDO',
         );
-        parent::__construct($options);
     }
 
     /**
@@ -59,6 +57,8 @@ class Sqlite extends AbstractDriver
      */
     public function setOptions(array $options = array())
     {
+        $options += $this->getDefaultOptions();
+
         $this->cachePath = rtrim($options['path'], '\\/') . DIRECTORY_SEPARATOR;
         $this->filePermissions = $options['filePermissions'];
         $this->dirPermissions = $options['dirPermissions'];

--- a/src/Stash/Driver/Sqlite.php
+++ b/src/Stash/Driver/Sqlite.php
@@ -59,21 +59,11 @@ class Sqlite extends AbstractDriver
      */
     public function setOptions(array $options = array())
     {
-        if (isset($options['path'])) {
-            $this->cachePath = rtrim($options['path'], '\\/') . DIRECTORY_SEPARATOR;
-        }
-        if (isset($options['filePermissions'])) {
-            $this->filePermissions = $options['filePermissions'];
-        }
-        if (isset($options['dirPermissions'])) {
-            $this->dirPermissions = $options['dirPermissions'];
-        }
-        if (isset($options['busyTimeout'])) {
-            $this->busyTimeout = $options['busyTimeout'];
-        }
-        if (isset($options['nesting'])) {
-            $this->nesting = $options['nesting'];
-        }
+        $this->cachePath = rtrim($options['path'], '\\/') . DIRECTORY_SEPARATOR;
+        $this->filePermissions = $options['filePermissions'];
+        $this->dirPermissions = $options['dirPermissions'];
+        $this->busyTimeout = $options['busyTimeout'];
+        $this->nesting = max((int) $options['nesting'], 0);
 
         Utilities::checkFileSystemPermissions($this->cachePath, $this->dirPermissions);
 

--- a/src/Stash/Driver/Sqlite.php
+++ b/src/Stash/Driver/Sqlite.php
@@ -14,7 +14,6 @@ namespace Stash\Driver;
 use Stash;
 use Stash\Utilities;
 use Stash\Exception\RuntimeException;
-use Stash\Interfaces\DriverInterface;
 
 /**
  * StashSqlite is a wrapper around one or more SQLite databases stored on the local system. While not as quick at at

--- a/src/Stash/Driver/Sqlite.php
+++ b/src/Stash/Driver/Sqlite.php
@@ -24,7 +24,7 @@ use Stash\Interfaces\DriverInterface;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class Sqlite implements DriverInterface
+class Sqlite extends AbstractDriver
 {
     protected $defaultOptions = array('filePermissions' => 0660,
                                       'dirPermissions' => 0770,
@@ -42,18 +42,6 @@ class Sqlite implements DriverInterface
     protected $subDrivers;
 
     protected $disabled = false;
-
-    /**
-     * Initializes the driver.
-     *
-     * @throws RuntimeException 'Extension is not installed.'
-     */
-    public function __construct()
-    {
-        if (!static::isAvailable()) {
-            throw new RuntimeException('Extension is not installed.');
-        }
-    }
 
     /**
      *
@@ -235,8 +223,6 @@ class Sqlite implements DriverInterface
 
     /**
      * Destroys the sub-drivers when this driver is unset -- required for Windows compatibility.
-     *
-     * {@inheritdoc}
      */
     public function __destruct()
     {

--- a/tests/Stash/Test/Driver/AbstractDriverTest.php
+++ b/tests/Stash/Test/Driver/AbstractDriverTest.php
@@ -226,7 +226,6 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testDestructor($driver)
     {
-        $driver->__destruct();
         $driver=null;
     }
 }

--- a/tests/Stash/Test/Driver/AbstractDriverTest.php
+++ b/tests/Stash/Test/Driver/AbstractDriverTest.php
@@ -77,18 +77,16 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             return false;
         }
 
-        $driver = new $driverClass();
-        $driver->setOptions($options);
+        $driver = new $driverClass($options);
 
         return $driver;
     }
 
-    public function testSetOptions()
+    public function testConstruction()
     {
         $driverType = $this->driverClass;
         $options = $this->getOptions();
-        $driver = new $driverType();
-        $driver->setOptions($options);
+        $driver = new $driverType($options);
         $this->assertTrue(is_a($driver, $driverType), 'Driver is an instance of ' . $driverType);
         $this->assertTrue(is_a($driver, '\Stash\Interfaces\DriverInterface'), 'Driver implments the Stash\Driver\DriverInterface interface');
 

--- a/tests/Stash/Test/Driver/AbstractDriverTest.php
+++ b/tests/Stash/Test/Driver/AbstractDriverTest.php
@@ -82,11 +82,12 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
         return $driver;
     }
 
-    public function testConstruction()
+    public function testSetOptions()
     {
         $driverType = $this->driverClass;
         $options = $this->getOptions();
-        $driver = new $driverType($options);
+        $driver = new $driverType();
+        $driver->setOptions($options);
         $this->assertTrue(is_a($driver, $driverType), 'Driver is an instance of ' . $driverType);
         $this->assertTrue(is_a($driver, '\Stash\Interfaces\DriverInterface'), 'Driver implments the Stash\Driver\DriverInterface interface');
 

--- a/tests/Stash/Test/Driver/ApcTest.php
+++ b/tests/Stash/Test/Driver/ApcTest.php
@@ -25,9 +25,12 @@ class ApcTest extends AbstractDriverTest
         $options = $this->getOptions();
         $options['namespace'] = 'namespace_test';
         $options['ttl'] = 15;
-        $driver = new $driverType($options);
+        $driver = new $driverType();
+        $driver->setOptions($options);
 
         $this->assertAttributeEquals('namespace_test', 'apcNamespace', $driver, 'APC is setting supplied namespace.');
         $this->assertAttributeEquals(15, 'ttl', $driver, 'APC is setting supplied ttl.');
+
+        return parent::testSetOptions();
     }
 }

--- a/tests/Stash/Test/Driver/ApcTest.php
+++ b/tests/Stash/Test/Driver/ApcTest.php
@@ -25,12 +25,9 @@ class ApcTest extends AbstractDriverTest
         $options = $this->getOptions();
         $options['namespace'] = 'namespace_test';
         $options['ttl'] = 15;
-        $driver = new $driverType();
-        $driver->setOptions($options);
+        $driver = new $driverType($options);
 
         $this->assertAttributeEquals('namespace_test', 'apcNamespace', $driver, 'APC is setting supplied namespace.');
         $this->assertAttributeEquals(15, 'ttl', $driver, 'APC is setting supplied ttl.');
-
-        return parent::testSetOptions();
     }
 }

--- a/tests/Stash/Test/Stubs/DriverCallCheckStub.php
+++ b/tests/Stash/Test/Stubs/DriverCallCheckStub.php
@@ -12,7 +12,7 @@
 namespace Stash\Test\Stubs;
 
 use Stash;
-use Stash\Interfaces\DriverInterface;
+use Stash\Driver\AbstractDriver;
 
 /**
  * DriverExceptionStub is used for testing how Stash reacts to thrown errors. Every function but the constructor throws
@@ -23,18 +23,10 @@ use Stash\Interfaces\DriverInterface;
  *
  * @codeCoverageIgnore
  */
-class DriverCallCheckStub implements DriverInterface
+class DriverCallCheckStub extends AbstractDriver
 {
     protected $store = array();
     protected $wasCalled = false;
-
-    public function setOptions(array $options = array())
-    {
-    }
-
-    public function __destruct()
-    {
-    }
 
     public function getData($key)
     {

--- a/tests/Stash/Test/Stubs/DriverExceptionStub.php
+++ b/tests/Stash/Test/Stubs/DriverExceptionStub.php
@@ -12,8 +12,8 @@
 namespace Stash\Test\Stubs;
 
 use Stash;
+use Stash\Driver\AbstractDriver;
 use Stash\Test\Exception\TestException;
-use Stash\Interfaces\DriverInterface;
 
 /**
  * DriverExceptionStub is used for testing how Stash reacts to thrown errors. Every function but the constructor throws
@@ -24,17 +24,9 @@ use Stash\Interfaces\DriverInterface;
  *
  * @codeCoverageIgnore
  */
-class DriverExceptionStub implements DriverInterface
+class DriverExceptionStub extends AbstractDriver
 {
     protected $store = array();
-
-    public function setOptions(array $options = array())
-    {
-    }
-
-    public function __destruct()
-    {
-    }
 
     public function getData($key)
     {

--- a/tests/Stash/Test/Stubs/DriverUnavailableStub.php
+++ b/tests/Stash/Test/Stubs/DriverUnavailableStub.php
@@ -12,8 +12,8 @@
 namespace Stash\Test\Stubs;
 
 use Stash;
+use Stash\Driver\AbstractDriver;
 use Stash\Test\Exception\TestException;
-use Stash\Interfaces\DriverInterface;
 
 /**
  * DriverExceptionStub is used for testing how Stash reacts to thrown errors. Every function but the constructor throws
@@ -24,17 +24,9 @@ use Stash\Interfaces\DriverInterface;
  *
  * @codeCoverageIgnore
  */
-class DriverUnavailableStub implements DriverInterface
+class DriverUnavailableStub extends AbstractDriver
 {
     protected $store = array();
-
-    public function setOptions(array $options = array())
-    {
-    }
-
-    public function __destruct()
-    {
-    }
 
     public function getData($key)
     {


### PR DESCRIPTION
* Fixes that the File and Sqlite drivers were not usable out of the box without calling setOptions() first.
* Fixes that __destruct() is not defined on the interface and does not need to be defined if it's simply a no-op empty function.

This resolves Issue #230 and maintains backwards compatibility.