### PR TITLE
Fix: Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ before_script:
 script: ./tests/runTests.sh
 
 after_script:
-  - php vendor/bin/coveralls -v
+    - php vendor/bin/coveralls -v
 
 services:
-  - redis-server
-  - memcached
+    - redis-server
+    - memcached
 
 matrix:
     fast_finish: true
     allow_failures:
-      - php: hhvm-nightly
-      - php: 7.0
+        - php: hhvm-nightly
+        - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,11 @@ php:
     - hhvm
     - hhvm-nightly
 
+before_install:
+    - composer self-update
+
 before_script:
-    - composer self-update && composer install
+    - composer install
     - tests/travis/php_setup.sh
     - tests/travis/redis_setup.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ php:
 before_install:
     - composer self-update
 
-before_script:
+install:
     - composer install
+
+before_script:
     - tests/travis/php_setup.sh
     - tests/travis/redis_setup.sh
 


### PR DESCRIPTION
This PR

* [x] updates Composer itself in the `before_install` section
* [x] installs dependencies with Composer in the `install` section
* [x] consistently indents the configuration file with 4 spaces (the majority of it already is)