### PR TITLE
Enhancement: Cache dependencies installed with Composer between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
     - 5.3
     - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ php:
     - hhvm
     - hhvm-nightly
 
+cache:
+    directories:
+        - $HOME/.composer/cache
+
 before_script:
     - composer self-update && composer install
     - tests/travis/php_setup.sh


### PR DESCRIPTION
This PR

* [x] caches dependencies installed with Composer between builds on Travis
* [x] directs builds to container-based infrastructure

For reference, see 

* http://docs.travis-ci.com/user/caching/#Arbitrary-directories.
* http://docs.travis-ci.com/user/workers/container-based-infrastructure/