### PR TITLE
Enhancement: Require fabpot/php-cs-fixer:^1.9

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,5 +8,4 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()
 return Symfony\CS\Config\Config::create()
     ->finder($finder)
     ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
-
 ;

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     "php": ">=5.3.0"
   },
   "require-dev": {
-      "phpunit/phpunit": "4.5.*",
-      "fabpot/php-cs-fixer": "1.5.*",
-      "satooshi/php-coveralls": "dev-master"
+    "fabpot/php-cs-fixer": "^1.9",
+    "phpunit/phpunit": "4.5.*",
+    "satooshi/php-coveralls": "dev-master"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This PR

* [x] updates `fabpot/php-cs-fixer`
* [x] removes an extra empty line from the `phpcs` configuration

:bulb: Note that I required the package using

```
$ composer require --dev --sort-packages fabpot/php-cs-fixer:^1.9
```

resulting in packages being nicely sorted and properly indented.