### PR TITLE
Fix: Remove hhvm-nightly from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
     - 5.6
     - 7.0
     - hhvm
-    - hhvm-nightly
 
 before_script:
     - composer self-update && composer install
@@ -26,5 +25,4 @@ services:
 matrix:
     fast_finish: true
     allow_failures:
-      - php: hhvm-nightly
       - php: 7.0


### PR DESCRIPTION
This PR

* [x] removes `hhvm-nightly` from the build matrix

See https://travis-ci.org/tedious/Stash/jobs/69835795#L68:

> HHVM nightly is no longer supported on Ubuntu Precise. See https://github.com/travis-ci/travis-ci/issues/3788 and https://github.com/facebook/hhvm/issues/5220