### PR TITLE
using cache keys as ArrayIterator keys

### DIFF
--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -156,7 +156,8 @@ class Pool implements PoolInterface
 
         $items = array();
         foreach ($keys as $key) {
-            $items[] = $this->getItem($key);
+            $item = $this->getItem($key);
+            $items[$item->getKey()] = $item;
         }
 
         return new \ArrayIterator($items);

--- a/tests/Stash/Test/AbstractPoolTest.php
+++ b/tests/Stash/Test/AbstractPoolTest.php
@@ -11,6 +11,7 @@
 
 namespace Stash\Test;
 
+use Stash\Exception\InvalidArgumentException;
 use Stash\Pool;
 use Stash\Driver\Ephemeral;
 use Stash\Test\Stubs\LoggerStub;
@@ -96,8 +97,7 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
 
         $cacheIterator = $pool->getItemIterator($keys);
         $keyData = $this->multiData;
-        foreach ($cacheIterator as $stash) {
-            $key = $stash->getKey();
+        foreach ($cacheIterator as $key => $stash) {
             $this->assertTrue($stash->isMiss(), 'new Cache in iterator is empty');
             $stash->set($keyData[$key]);
             unset($keyData[$key]);
@@ -105,8 +105,8 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $keyData, 'all keys are accounted for the in cache iterator');
 
         $cacheIterator = $pool->getItemIterator($keys);
-        foreach ($cacheIterator as $stash) {
-            $key = $stash->getKey();
+        foreach ($cacheIterator as $key => $stash) {
+            $this->assertEquals($key, $stash->getKey(), 'Item key is not equals key in iterator');
             $data = $stash->get($key);
             $this->assertEquals($this->multiData[$key], $data, 'data put into the pool comes back the same through iterators.');
         }
@@ -222,6 +222,9 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('critical', $logger->lastLevel, 'Exceptions logged as critical.');
     }
 
+    /**
+     * @return \Stash\Pool
+     */
     protected function getTestPool()
     {
         return new $this->poolClass();


### PR DESCRIPTION
With this patch we can access to Item by key:
```php
$pool = new Stash\Pool();
$result = $pool->getItemIterator(array('TEST1', 'TEST2'));
echo $result['TEST2']->get();
```