### PR TITLE
do not set isHit if data is empty on Invalidation::OLD

### DIFF
--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -549,7 +549,7 @@ class Item implements ItemInterface
                 break;
 
             case Invalidation::OLD:
-                $this->isHit = true;
+                $this->isHit = $record['data']['return'] !== null;
                 break;
 
             default:


### PR DESCRIPTION
In case when cache is empty and two (or more) clients asks cached data we got abnormal situation: first client locks cache, and other got isHit = true but we have no old value and data is null.

For ex.
```
<?php
class Something {
    public function getObject($key) {
        $item = $pool->getItem($key);
        $data = $item->get(Invalidation::OLD);
        if ($item->isMiss()) {
            $item->lock(5);
            // long query from DB
            $data = ORM::getByKey($key);
            $item->set($data, 3600);
        }
        return $data;
    }

    // ....some times later we call this method...
    public function someFunc() {
        return $this->getObject('my-key')
            ->getSomeField(); // for non first clients this will trigger fatal error because $data is null
    }
}
```