### PR TITLE
Bring Stash current with PSR6 for v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## Stash v1.0.0 Changelog
+
+### v1.0.0
+
+* The `set` function no longer persists data.
+
+* Removed expiration time for `set` function
+
+* Added `expiresAt` and `expiresAfter` functions to the Item class.
+
+* `getExpiration` to return current datetime when no record exists.
+
+* Added `save` function to ItemInterface.
+
+* Changed `getItemIterator` to `getItems`
+
+* RuntimeException now extends from \RuntimeException
+
+* Added `isHit` function to ItemInterface.
+
+* Added the "exists" function, which should mostly be avoided.
+
+
 ## Stash v0.13 Changelog
 
 ### 0.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@
 
 * Added `isHit` function to ItemInterface.
 
-* Added the "exists" function, which should mostly be avoided.
+* Added the `exists` function to ItemInterface, which should mostly be avoided.
+
+* Added the `exists` function to the Pool, which should mostly be avoided.
 
 
 ## Stash v0.13 Changelog

--- a/src/Stash/Exception/WindowsPathMaxLengthException.php
+++ b/src/Stash/Exception/WindowsPathMaxLengthException.php
@@ -28,7 +28,7 @@ namespace Stash\Exception;
  * @package Stash\Exception
  * @author Jonathan Chan <jc@jmccc.com>
  */
-class WindowsPathMaxLengthException extends \Exception implements Exception
+class WindowsPathMaxLengthException extends RuntimeException implements Exception
 {
     public function __construct($message="", $code=0, $previous=null)
     {

--- a/src/Stash/Interfaces/ItemInterface.php
+++ b/src/Stash/Interfaces/ItemInterface.php
@@ -68,6 +68,14 @@ interface ItemInterface
     public function get();
 
     /**
+     * Returns true if the cached item is valid and usable.
+     *
+     * @return bool
+     */
+    public function isHit();
+
+
+    /**
      * Returns true if the cached item needs to be refreshed.
      *
      * @return bool

--- a/src/Stash/Interfaces/ItemInterface.php
+++ b/src/Stash/Interfaces/ItemInterface.php
@@ -140,8 +140,34 @@ interface ItemInterface
     public function getExpiration();
 
 
-
+    /**
+    * Sets the expiration based off of an integer or DateInterval
+    *
+    * @param int|\DateInterval $time
+    * @return static The invoked object.
+    */
     public function expiresAfter($time);
+
+
+    /**
+    * Sets the expiration to a specific time.
+    *
+    * @param \DateTimeInterface $expiration
+    * @return static The invoked object.
+    */
     public function expiresAt($expiration);
+
+
+    /**
+    * Persists the Item's value to the backend storage.
+    *
+    * @return bool
+    */
     public function save();
+
+
+    /**
+    * @return boolean True if item exists in the cache, false otherwise.
+    */
+   public function exists();
 }

--- a/src/Stash/Interfaces/ItemInterface.php
+++ b/src/Stash/Interfaces/ItemInterface.php
@@ -92,10 +92,9 @@ interface ItemInterface
      * unable to be serialized.
      *
      * @param  mixed              $data bool
-     * @param  int|\DateTime|null $ttl  Int is time (seconds), DateTime a future expiration date
      * @return bool               Returns whether the object was successfully stored or not.
      */
-    public function set($data, $ttl = null);
+    public function set($data);
 
     /**
      * Extends the expiration on the current cached item. For some engines this

--- a/src/Stash/Interfaces/ItemInterface.php
+++ b/src/Stash/Interfaces/ItemInterface.php
@@ -63,12 +63,9 @@ interface ItemInterface
      * function after call this one. If no value is stored at all then this
      * function will return null.
      *
-     * @param  int        $invalidation
-     * @param  null       $arg
-     * @param  null       $arg2
      * @return mixed|null
      */
-    public function get($invalidation = 0, $arg = null, $arg2 = null);
+    public function get();
 
     /**
      * Returns true if the cached item needs to be refreshed.

--- a/src/Stash/Interfaces/ItemInterface.php
+++ b/src/Stash/Interfaces/ItemInterface.php
@@ -135,4 +135,5 @@ interface ItemInterface
 
     public function expiresAfter($time);
     public function expiresAt($expiration);
+    public function save();
 }

--- a/src/Stash/Interfaces/ItemInterface.php
+++ b/src/Stash/Interfaces/ItemInterface.php
@@ -134,4 +134,9 @@ interface ItemInterface
      * @return \DateTime
      */
     public function getExpiration();
+
+
+
+    public function expiresAfter($time);
+    public function expiresAt($expiration);
 }

--- a/src/Stash/Interfaces/PoolInterface.php
+++ b/src/Stash/Interfaces/PoolInterface.php
@@ -133,4 +133,5 @@ interface PoolInterface
     public function saveDeferred($item);
     public function save($item);
     public function deleteItems(array $keys);
+    public function exists($key);
 }

--- a/src/Stash/Interfaces/PoolInterface.php
+++ b/src/Stash/Interfaces/PoolInterface.php
@@ -127,4 +127,10 @@ interface PoolInterface
      * @return bool
      */
     public function setLogger($logger);
+
+
+    public function commit();
+    public function saveDeferred($item);
+    public function save($item);
+    public function deleteItems(array $keys);
 }

--- a/src/Stash/Interfaces/PoolInterface.php
+++ b/src/Stash/Interfaces/PoolInterface.php
@@ -66,7 +66,7 @@ interface PoolInterface
      * @param  array     $keys
      * @return \Iterator
      */
-    public function getItemIterator($keys);
+    public function getItems($keys);
 
     /**
      * Empties the entire cache pool of all Items.

--- a/src/Stash/Interfaces/PoolInterface.php
+++ b/src/Stash/Interfaces/PoolInterface.php
@@ -128,10 +128,39 @@ interface PoolInterface
      */
     public function setLogger($logger);
 
-
+    /**
+    * Forces any save-deferred objects to get flushed to the backend drivers.
+    */
     public function commit();
+
+    /**
+    * Sets an Item to be saved at some point. This allows buffering for
+    * multi-save events.
+    *
+    * @param CacheItemInterface $item
+    * @return static The invoked object.
+    */
     public function saveDeferred($item);
+
+    /**
+    * Sets an Item to be saved immediately.
+    *
+    * @param CacheItemInterface $item
+    * @return static The invoked object.
+    */
     public function save($item);
+
+    /**
+     * Removes multiple items from the pool.
+     *
+     * @param array $keys
+     * @return static The invoked object.
+     */
     public function deleteItems(array $keys);
-    public function exists($key);
+
+
+    /**
+    * @return boolean True if item exists in the cache, false otherwise.
+    */
+    public function exists();
 }

--- a/src/Stash/Interfaces/PoolInterface.php
+++ b/src/Stash/Interfaces/PoolInterface.php
@@ -160,7 +160,10 @@ interface PoolInterface
 
 
     /**
+    * Checks for the existance of an item in the cache.
+    *
+    * @param  array|string $key    
     * @return boolean True if item exists in the cache, false otherwise.
     */
-    public function exists();
+    public function exists($key);
 }

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -375,8 +375,8 @@ class Item implements ItemInterface
 
     public function expiresAt($expiration = null)
     {
-        if(!is_null($expiration) && !($expiration instanceof \DateTimeInterface)) {
-          throw new InvalidArgumentException('expiresAt requires \DateTimeInterface or null');
+        if (!is_null($expiration) && !($expiration instanceof \DateTimeInterface)) {
+            throw new InvalidArgumentException('expiresAt requires \DateTimeInterface or null');
         }
 
         $this->expiration = $expiration;

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -580,13 +580,13 @@ class Item implements ItemInterface
     public function getExpiration()
     {
         $record = $this->getRecord();
+        $dateTime = new \DateTime();
+
         if (!isset($record['expiration'])) {
-            return false;
+            return $dateTime;
         }
 
-        $dateTime = new \DateTime();
         $dateTime->setTimestamp($record['expiration']);
-
         return $dateTime;
     }
 

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -321,7 +321,7 @@ class Item implements ItemInterface
     /**
      * {@inheritdoc}
      */
-    public function set($data, $ttl = null)
+    public function set($data)
     {
         if (!isset($this->key)) {
             return false;
@@ -332,7 +332,6 @@ class Item implements ItemInterface
         }
 
         $this->data = $data;
-        $this->setTTL($ttl);
         return $this;
     }
 

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -472,6 +472,27 @@ class Item implements ItemInterface
     /**
      * {@inheritdoc}
      */
+    public function exists()
+    {
+        if ($this->isDisabled()) {
+            return false;
+        }
+        $storedData = $this->driver->getData($this->key);
+
+        if ($storedData === false) {
+            return false;
+        }
+
+        if (!is_array($storedData)) {
+            return false;
+        }
+
+        return isset($storedData['data']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isDisabled()
     {
         return self::$runtimeDisable

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -12,6 +12,7 @@
 namespace Stash;
 
 use Stash\Exception\Exception;
+use Stash\Exception\InvalidArgumentException;
 use Stash\Interfaces\DriverInterface;
 use Stash\Interfaces\ItemInterface;
 use Stash\Interfaces\PoolInterface;
@@ -374,6 +375,10 @@ class Item implements ItemInterface
 
     public function expiresAt($expiration = null)
     {
+        if(!is_null($expiration) && !($expiration instanceof \DateTimeInterface)) {
+          throw new InvalidArgumentException('expiresAt requires \DateTimeInterface or null');
+        }
+
         $this->expiration = $expiration;
         return $this;
     }

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -323,26 +323,54 @@ class Item implements ItemInterface
      */
     public function set($data, $ttl = null)
     {
+        if (!isset($this->key)) {
+            return false;
+        }
+
         if ($this->isDisabled()) {
             return false;
         }
 
         $this->data = $data;
+        $this->setTTL($ttl);
+        return $this;
+    }
 
-        if (is_numeric($ttl)) {
-            $dateInterval = \DateInterval::createFromDateString(abs($ttl) . ' seconds');
-            $date = new \DateTime();
-            if ($ttl > 0) {
+    public function setTTL($ttl = null)
+    {
+        if (is_numeric($ttl) || ($ttl instanceof \DateInterval)) {
+            $this->expiresAfter($ttl);
+        } elseif ($ttl instanceof \DateTimeInterface) {
+            $this->expiresAt($ttl);
+        } else {
+            $this->expiration = null;
+        }
+    }
+
+    public function expiresAt($expiration = null)
+    {
+        $this->expiration = $expiration;
+        return $this;
+    }
+
+    public function expiresAfter($time)
+    {
+        $date = new \DateTime();
+        if (is_numeric($time)) {
+            $dateInterval = \DateInterval::createFromDateString(abs($time) . ' seconds');
+            if ($time > 0) {
                 $date->add($dateInterval);
             } else {
                 $date->sub($dateInterval);
             }
             $this->expiration = $date;
-        } elseif ($ttl instanceof \DateTime) {
-            $this->expiration = $ttl;
+        } elseif ($time instanceof \DateInterval) {
+            $date->add($time);
+            $this->expiration = $date;
+        } else {
         }
 
-        return $this->save();
+        return $this;
     }
 
     public function save()

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -377,8 +377,8 @@ class Item implements ItemInterface
     {
         if (!is_null($expiration) && !($expiration instanceof \DateTimeInterface)) {
             # For compatbility with PHP 5.4 we also allow inheriting from the DateTime object.
-            if(!($expiration instanceof \DateTime)) {
-              throw new InvalidArgumentException('expiresAt requires \DateTimeInterface or null');
+            if (!($expiration instanceof \DateTime)) {
+                throw new InvalidArgumentException('expiresAt requires \DateTimeInterface or null');
             }
         }
 

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -252,9 +252,9 @@ class Item implements ItemInterface
 
     public function setInvalidationMethod($invalidation = Invalidation::PRECOMPUTE, $arg = null, $arg2 = null)
     {
-      $this->invalidationMethod = $invalidation;
-      $this->invalidationArg1 = $arg;
-      $this->invalidationArg2 = $arg2;
+        $this->invalidationMethod = $invalidation;
+        $this->invalidationArg1 = $arg;
+        $this->invalidationArg2 = $arg2;
     }
 
     private function executeGet($invalidation = Invalidation::PRECOMPUTE, $arg = null, $arg2 = null)

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -365,7 +365,7 @@ class Item implements ItemInterface
     {
         if (is_numeric($ttl) || ($ttl instanceof \DateInterval)) {
             return $this->expiresAfter($ttl);
-        } elseif ($ttl instanceof \DateTimeInterface) {
+        } elseif (($ttl instanceof \DateTimeInterface) || ($ttl instanceof \DateTime)) {
             return $this->expiresAt($ttl);
         } else {
             $this->expiration = null;

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -376,7 +376,10 @@ class Item implements ItemInterface
     public function expiresAt($expiration = null)
     {
         if (!is_null($expiration) && !($expiration instanceof \DateTimeInterface)) {
-            throw new InvalidArgumentException('expiresAt requires \DateTimeInterface or null');
+            # For compatbility with PHP 5.4 we also allow inheriting from the DateTime object.
+            if(!($expiration instanceof \DateTime)) {
+              throw new InvalidArgumentException('expiresAt requires \DateTimeInterface or null');
+            }
         }
 
         $this->expiration = $expiration;

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -512,16 +512,6 @@ class Item implements ItemInterface
     }
 
     /**
-     * Sets the driver this object uses to interact with the caching system.
-     *
-     * @param DriverInterface $driver
-     */
-    protected function setDriver(DriverInterface $driver)
-    {
-        $this->driver = $driver;
-    }
-
-    /**
      * Logs an exception with the Logger class, if it exists.
      *
      * @param  string     $message

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -294,6 +294,15 @@ class Item implements ItemInterface
         return isset($record['data']['return']) ? $record['data']['return'] : null;
     }
 
+
+    /**
+    * {@inheritdoc}
+    */
+    public function isHit()
+    {
+        return !$this->isMiss();
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -228,7 +228,7 @@ class Item implements ItemInterface
     public function get($invalidation = Invalidation::PRECOMPUTE, $arg = null, $arg2 = null)
     {
         try {
-            if(!isset($this->data)) {
+            if (!isset($this->data)) {
                 $this->data = $this->executeGet($invalidation, $arg, $arg2);
             }
 
@@ -323,38 +323,38 @@ class Item implements ItemInterface
      */
     public function set($data, $ttl = null)
     {
-      if ($this->isDisabled()) {
-          return false;
-      }
-
-      $this->data = $data;
-
-      if(is_numeric($ttl)) {
-        $dateInterval = \DateInterval::createFromDateString(abs($ttl) . ' seconds');
-        $date = new \DateTime();
-        if($ttl > 0) {
-          $date->add($dateInterval);
-        } else {
-          $date->sub($dateInterval);
+        if ($this->isDisabled()) {
+            return false;
         }
-        $this->expiration = $date;
-      } elseif ($ttl instanceof \DateTime) {
-        $this->expiration = $ttl;
-      }
 
-      return $this->save();
+        $this->data = $data;
+
+        if (is_numeric($ttl)) {
+            $dateInterval = \DateInterval::createFromDateString(abs($ttl) . ' seconds');
+            $date = new \DateTime();
+            if ($ttl > 0) {
+                $date->add($dateInterval);
+            } else {
+                $date->sub($dateInterval);
+            }
+            $this->expiration = $date;
+        } elseif ($ttl instanceof \DateTime) {
+            $this->expiration = $ttl;
+        }
+
+        return $this->save();
     }
 
     public function save()
     {
-      try {
-          return $this->executeSet($this->data, $this->expiration);
-      } catch (Exception $e) {
-          $this->logException('Setting value in cache caused exception.', $e);
-          $this->disable();
+        try {
+            return $this->executeSet($this->data, $this->expiration);
+        } catch (Exception $e) {
+            $this->logException('Setting value in cache caused exception.', $e);
+            $this->disable();
 
-          return false;
-      }
+            return false;
+        }
     }
 
     private function executeSet($data, $time)
@@ -613,15 +613,15 @@ class Item implements ItemInterface
      */
     public function getExpiration()
     {
-        if(!isset($this->expiration)) {
-          $record = $this->getRecord();
-          $dateTime = new \DateTime();
+        if (!isset($this->expiration)) {
+            $record = $this->getRecord();
+            $dateTime = new \DateTime();
 
-          if (!isset($record['expiration'])) {
-              return $dateTime;
-          }
+            if (!isset($record['expiration'])) {
+                return $dateTime;
+            }
 
-          $this->expiration = $dateTime->setTimestamp($record['expiration']);
+            $this->expiration = $dateTime->setTimestamp($record['expiration']);
         }
 
         return $this->expiration;

--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -165,6 +165,47 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
+    public function save($item)
+    {
+        $item->save();
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveDeferred($item)
+    {
+        return $this->save($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        return true;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItems(array $keys)
+    {
+        // temporarily cheating here by wrapping around single calls.
+
+        $items = array();
+        foreach ($keys as $key) {
+            $items[] = $this->getItem($key)->clear();
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function flush()
     {
         if ($this->isDisabled) {

--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -198,7 +198,7 @@ class Pool implements PoolInterface
 
         $items = array();
         foreach ($keys as $key) {
-            $items[] = $this->getItem($key)->clear();
+            $this->getItem($key)->clear();
         }
 
         return $this;

--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -150,7 +150,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function getItemIterator($keys)
+    public function getItems($keys)
     {
         // temporarily cheating here by wrapping around single calls.
 

--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -166,6 +166,14 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
+    public function exists($key)
+    {
+        return $this->getItem($key)->isHit();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function save($item)
     {
         $item->save();

--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -274,10 +274,6 @@ class Pool implements PoolInterface
      */
     public function getDriver()
     {
-        if (!isset($this->driver)) {
-            $this->driver = new Ephemeral();
-        }
-
         return $this->driver;
     }
 

--- a/src/Stash/Session.php
+++ b/src/Stash/Session.php
@@ -184,7 +184,7 @@ class Session implements \SessionHandlerInterface
     {
         $cache = $this->getCache($session_id);
 
-        return $cache->set($session_data, $this->options['ttl'])->save();
+        return $cache->set($session_data)->expiresAfter($this->options['ttl'])->save();
     }
 
     /**

--- a/src/Stash/Session.php
+++ b/src/Stash/Session.php
@@ -184,7 +184,7 @@ class Session implements \SessionHandlerInterface
     {
         $cache = $this->getCache($session_id);
 
-        return $cache->set($session_data, $this->options['ttl']);
+        return $cache->set($session_data, $this->options['ttl'])->save();
     }
 
     /**

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -341,6 +341,22 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(!$stash->isMiss(), 'isMiss returns false for valid data');
     }
 
+    public function testIsHit()
+    {
+        $stash = $this->testConstruct(array('This', 'Should', 'Fail'));
+        $this->assertFalse($stash->isHit(), 'isHit returns false for missing data');
+        $data = $stash->get();
+        $this->assertNull($data, 'getData returns null for missing data');
+
+        $key = array('isHit', 'test');
+
+        $stash = $this->testConstruct($key);
+        $stash->set('testString')->save();
+
+        $stash = $this->testConstruct($key);
+        $this->assertTrue($stash->isHit(), 'isHit returns true for valid data');
+    }
+
     public function testClear()
     {
         // repopulate

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -112,7 +112,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
             $this->assertAttributeInternalType('string', 'keyString', $stash, 'Argument based keys setup keystring');
             $this->assertAttributeInternalType('array', 'key', $stash, 'Argument based keys setup key');
 
-            $this->assertTrue($stash->set($value), 'Driver class able to store data type ' . $type);
+            $this->assertTrue($stash->set($value)->save(), 'Driver class able to store data type ' . $type);
         }
 
         $item = $this->getItem();
@@ -130,7 +130,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         foreach ($this->data as $type => $value) {
             $key = array('base', $type);
             $stash = $this->testConstruct($key);
-            $stash->set($value);
+            $stash->set($value)->save();
 
             // new object, but same backend
             $stash = $this->testConstruct($key);
@@ -180,7 +180,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         $newValue = 'newValue';
 
         $runningStash = $this->testConstruct($key);
-        $runningStash->set($oldValue, -300);
+        $runningStash->set($oldValue, -300)->save();
 
         // Test without stampede
         $controlStash = $this->testConstruct($key);
@@ -234,7 +234,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         unset($unknownStash);
 
         // Test that storing the cache turns off stampede mode.
-        $runningStash->set($newValue, 30);
+        $runningStash->set($newValue, 30)->save();
         $this->assertAttributeEquals(false, 'stampedeRunning', $runningStash, 'Stampede flag is off.');
         unset($runningStash);
 
@@ -255,7 +255,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         // Test Stampede Flag Expiration
         $key = array('stampede', 'expire');
         $Item_SPtest = $this->testConstruct($key);
-        $Item_SPtest->set($oldValue, -300);
+        $Item_SPtest->set($oldValue, -300)->save();
         $Item_SPtest->lock(-5);
         $this->assertEquals($oldValue, $Item_SPtest->get(Item::SP_VALUE, $newValue), 'Expired lock is ignored');
     }
@@ -267,7 +267,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
 
         $key = array('base', 'expiration', 'test');
         $stash = $this->testConstruct($key);
-        $stash->set(array(1, 2, 3, 'apples'), $expiration);
+        $stash->set(array(1, 2, 3, 'apples'), $expiration)->save();
 
         $stash = $this->testConstruct($key);
         $data = $stash->get();
@@ -285,7 +285,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($stash->getCreation(), 'no record exists yet, return null');
 
-        $stash->set(array('stuff'), $creation);
+        $stash->set(array('stuff'), $creation)->save();
 
         $stash = $this->testConstruct($key);
         $createdOn = $stash->getCreation();
@@ -312,7 +312,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
 
         #$this->assertFalse($stash->getExpiration(), 'no record exists yet, return null');
 
-        $stash->set(array('stuff'), $expiration);
+        $stash->set(array('stuff'), $expiration)->save();
 
         $stash = $this->testConstruct($key);
         $itemExpiration = $stash->getExpiration();
@@ -331,7 +331,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         $key = array('isMiss', 'test');
 
         $stash = $this->testConstruct($key);
-        $stash->set('testString');
+        $stash->set('testString')->save();
 
         $stash = $this->testConstruct($key);
         $this->assertTrue(!$stash->isMiss(), 'isMiss returns false for valid data');
@@ -343,11 +343,11 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         foreach ($this->data as $type => $value) {
             $key = array('base', $type);
             $stash = $this->testConstruct($key);
-            $stash->set($value);
+            $stash->set($value)->save();
             $this->assertAttributeInternalType('string', 'keyString', $stash, 'Argument based keys setup keystring');
             $this->assertAttributeInternalType('array', 'key', $stash, 'Argument based keys setup key');
 
-            $this->assertTrue($stash->set($value), 'Driver class able to store data type ' . $type);
+            $this->assertTrue($stash->set($value)->save(), 'Driver class able to store data type ' . $type);
         }
 
         foreach ($this->data as $type => $value) {
@@ -376,7 +376,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         foreach ($this->data as $type => $value) {
             $key = array('base', $type);
             $stash = $this->testConstruct($key);
-            $stash->set($value);
+            $stash->set($value)->save();
         }
 
         // clear
@@ -406,10 +406,11 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
 
 
             $stash = $this->testConstruct($key);
-            $stash->set($value, -600);
+            $stash->set($value, -600)->save();
 
             $stash = $this->testConstruct($key);
-            $this->assertTrue($stash->extend(), 'extend returns true');
+            $this->assertEquals($stash->extend(), $stash, 'extend returns item object');
+            $stash->save();
 
             $stash = $this->testConstruct($key);
             $data = $stash->get();

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -180,7 +180,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         $newValue = 'newValue';
 
         $runningStash = $this->testConstruct($key);
-        $runningStash->set($oldValue, -300)->save();
+        $runningStash->set($oldValue)->expiresAfter(-300)->save();
 
         // Test without stampede
         $controlStash = $this->testConstruct($key);
@@ -234,7 +234,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         unset($unknownStash);
 
         // Test that storing the cache turns off stampede mode.
-        $runningStash->set($newValue, 30)->save();
+        $runningStash->set($newValue)->expiresAfter(30)->save();
         $this->assertAttributeEquals(false, 'stampedeRunning', $runningStash, 'Stampede flag is off.');
         unset($runningStash);
 
@@ -255,7 +255,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         // Test Stampede Flag Expiration
         $key = array('stampede', 'expire');
         $Item_SPtest = $this->testConstruct($key);
-        $Item_SPtest->set($oldValue, -300)->save();
+        $Item_SPtest->set($oldValue)->expiresAfter(-300)->save();
         $Item_SPtest->lock(-5);
         $this->assertEquals($oldValue, $Item_SPtest->get(Item::SP_VALUE, $newValue), 'Expired lock is ignored');
     }
@@ -267,7 +267,10 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
 
         $key = array('base', 'expiration', 'test');
         $stash = $this->testConstruct($key);
-        $stash->set(array(1, 2, 3, 'apples'), $expiration)->save();
+
+        $stash->set(array(1, 2, 3, 'apples'))
+          ->expiresAt($expiration)
+          ->save();
 
         $stash = $this->testConstruct($key);
         $data = $stash->get();
@@ -312,7 +315,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
 
         #$this->assertFalse($stash->getExpiration(), 'no record exists yet, return null');
 
-        $stash->set(array('stuff'), $expiration)->save();
+        $stash->set(array('stuff'))->expiresAt($expiration)->save();
 
         $stash = $this->testConstruct($key);
         $itemExpiration = $stash->getExpiration();

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -154,13 +154,12 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
     public function testGetItemInvalidKey()
     {
         try {
-          $item = $this->getItem();
-          $poolStub = new PoolGetDriverStub();
-          $poolStub->setDriver(new Ephemeral(array()));
-          $item->setPool($poolStub);
-          $item->setKey('This is not an array');
-        }
-        catch (\Exception $expected) {
+            $item = $this->getItem();
+            $poolStub = new PoolGetDriverStub();
+            $poolStub->setDriver(new Ephemeral(array()));
+            $item->setPool($poolStub);
+            $item->setKey('This is not an array');
+        } catch (\Exception $expected) {
             return;
         }
 

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -184,8 +184,8 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
 
         // Test without stampede
         $controlStash = $this->testConstruct($key);
-
-        $return = $controlStash->get(Item::SP_VALUE, $newValue);
+        $controlStash->setInvalidationMethod(Item::SP_VALUE, $newValue);
+        $return = $controlStash->get();
         $this->assertEquals($oldValue, $return, 'Old value is returned');
         $this->assertTrue($controlStash->isMiss());
         unset($controlStash);
@@ -196,7 +196,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
 
         // Old
         $oldStash = $this->testConstruct($key);
-
+        $oldStash->setInvalidationMethod(Item::SP_OLD);
         $return = $oldStash->get(Item::SP_OLD);
         $this->assertEquals($oldValue, $return, 'Old value is returned');
         $this->assertFalse($oldStash->isMiss());
@@ -204,7 +204,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
 
         // Value
         $valueStash = $this->testConstruct($key);
-
+        $valueStash->setInvalidationMethod(Item::SP_VALUE, $newValue);
         $return = $valueStash->get(Item::SP_VALUE, $newValue);
         $this->assertEquals($newValue, $return, 'New value is returned');
         $this->assertFalse($valueStash->isMiss());
@@ -212,9 +212,9 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
 
         // Sleep
         $sleepStash = $this->testConstruct($key);
-
+        $sleepStash->setInvalidationMethod(Item::SP_SLEEP, 250, 2);
         $start = microtime(true);
-        $return = $sleepStash->get(array(Item::SP_SLEEP, 250, 2));
+        $return = $sleepStash->get();
         $end = microtime(true);
 
         $this->assertTrue($sleepStash->isMiss());
@@ -240,24 +240,25 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
 
         // Precompute - test outside limit
         $precomputeStash = $this->testConstruct($key);
-
+        $precomputeStash->setInvalidationMethod(Item::SP_PRECOMPUTE, 10);
         $return = $precomputeStash->get(Item::SP_PRECOMPUTE, 10);
         $this->assertFalse($precomputeStash->isMiss(), 'Cache is marked as hit');
         unset($precomputeStash);
 
         // Precompute - test inside limit
         $precomputeStash = $this->testConstruct($key);
-
-        $return = $precomputeStash->get(Item::SP_PRECOMPUTE, 35);
+        $precomputeStash->setInvalidationMethod(Item::SP_PRECOMPUTE, 35);
+        $return = $precomputeStash->get();
         $this->assertTrue($precomputeStash->isMiss(), 'Cache is marked as miss');
         unset($precomputeStash);
 
         // Test Stampede Flag Expiration
         $key = array('stampede', 'expire');
         $Item_SPtest = $this->testConstruct($key);
+        $Item_SPtest->setInvalidationMethod(Item::SP_VALUE, $newValue);
         $Item_SPtest->set($oldValue)->expiresAfter(-300)->save();
         $Item_SPtest->lock(-5);
-        $this->assertEquals($oldValue, $Item_SPtest->get(Item::SP_VALUE, $newValue), 'Expired lock is ignored');
+        $this->assertEquals($oldValue, $Item_SPtest->get(), 'Expired lock is ignored');
     }
 
     public function testSetWithDateTime()

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -357,6 +357,22 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($stash->isHit(), 'isHit returns true for valid data');
     }
 
+    public function testExists()
+    {
+        $stash = $this->testConstruct(array('This', 'Should', 'Fail'));
+        $this->assertFalse($stash->exists(), 'exists returns false for missing data');
+        $data = $stash->get();
+        $this->assertNull($data, 'getData returns null for missing data');
+
+        $key = array('isHit', 'test');
+
+        $stash = $this->testConstruct($key);
+        $stash->set('testString')->save();
+
+        $stash = $this->testConstruct($key);
+        $this->assertTrue($stash->exists(), 'exists returns true for valid data');
+    }
+
     public function testClear()
     {
         // repopulate

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -303,7 +303,14 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         $key = array('getExpiration', 'test');
         $stash = $this->testConstruct($key);
 
-        $this->assertFalse($stash->getExpiration(), 'no record exists yet, return null');
+
+        $currentDate = new \DateTime();
+        $returnedDate = $stash->getExpiration();
+
+        $this->assertLessThanOrEqual(2, $currentDate->getTimestamp() -  $returnedDate->getTimestamp(), 'No record set, return as expired.');
+        $this->assertLessThanOrEqual(2, $returnedDate->getTimestamp() -  $currentDate->getTimestamp(), 'No record set, return as expired.');
+
+        #$this->assertFalse($stash->getExpiration(), 'no record exists yet, return null');
 
         $stash->set(array('stuff'), $expiration);
 

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -272,7 +272,7 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         $stash->set(array(1, 2, 3, 'apples'))
           ->setTTL($expiration)
           ->save();
-        $this->assertEquals($expiration, $stash->getExpiration());
+        $this->assertLessThanOrEqual($expiration->getTimestamp(), $stash->getExpiration()->getTimestamp());
 
         $stash = $this->testConstruct($key);
         $data = $stash->get();

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -300,7 +300,6 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
 
     public function testSetTTLNulll()
     {
-
         $key = array('ttl', 'expiration', 'test');
         $stash = $this->testConstruct($key);
         $stash->set(array(1, 2, 3, 'apples'))

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -151,17 +151,20 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $item->get(), 'Item without key returns null for get.');
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error
-     * @expectedExceptionMessage Argument 1 passed to Stash\Item::setKey()
-     */
     public function testGetItemInvalidKey()
     {
-        $item = $this->getItem();
-        $poolStub = new PoolGetDriverStub();
-        $poolStub->setDriver(new Ephemeral(array()));
-        $item->setPool($poolStub);
-        $item->setKey('This is not an array');
+        try {
+          $item = $this->getItem();
+          $poolStub = new PoolGetDriverStub();
+          $poolStub->setDriver(new Ephemeral(array()));
+          $item->setPool($poolStub);
+          $item->setKey('This is not an array');
+        }
+        catch (\Exception $expected) {
+            return;
+        }
+
+        $this->fail('An expected exception has not been raised.');
     }
 
     public function testLock()

--- a/tests/Stash/Test/AbstractPoolTest.php
+++ b/tests/Stash/Test/AbstractPoolTest.php
@@ -73,6 +73,7 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
     {
         $pool = $this->getTestPool();
 
+        $this->assertFalse($pool->exists('base/one'), 'Pool->exists() returns false for item without stored data.');
         $item = $pool->getItem('base', 'one');
         $this->assertInstanceOf('Stash\Item', $item, 'getItem returns a Stash\Item object');
 
@@ -88,10 +89,22 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
         $storedData = $item->get();
         $this->assertEquals($this->data, $storedData, 'Pool->save() returns proper data on new Item instance.');
 
+        $this->assertTrue($pool->exists('base/one'), 'Pool->exists() returns true for item with stored data.');
+
         $pool->setNamespace('TestNamespace');
         $item = $pool->getItem(array('test', 'item'));
 
         $this->assertAttributeEquals('TestNamespace', 'namespace', $item, 'Pool sets Item namespace.');
+    }
+
+    public function testExists()
+    {
+        $pool = $this->getTestPool();
+        $this->assertFalse($pool->exists('base/one'), 'Pool->exists() returns false for item without stored data.');
+        $item = $pool->getItem('base', 'one');
+        $item->set($this->data);
+        $pool->save($item);
+        $this->assertTrue($pool->exists('base/one'), 'Pool->exists() returns true for item with stored data.');
     }
 
     public function testCommit()

--- a/tests/Stash/Test/AbstractPoolTest.php
+++ b/tests/Stash/Test/AbstractPoolTest.php
@@ -55,7 +55,7 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
         $stash = $pool->getItem('base', 'one');
         $this->assertInstanceOf('Stash\Item', $stash, 'getItem returns a Stash\Item object');
 
-        $stash->set($this->data);
+        $stash->set($this->data)->save();
         $storedData = $stash->get();
         $this->assertEquals($this->data, $storedData, 'getItem returns working Stash\Item object');
 
@@ -99,7 +99,7 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
         foreach ($cacheIterator as $stash) {
             $key = $stash->getKey();
             $this->assertTrue($stash->isMiss(), 'new Cache in iterator is empty');
-            $stash->set($keyData[$key]);
+            $stash->set($keyData[$key])->save();
             unset($keyData[$key]);
         }
         $this->assertCount(0, $keyData, 'all keys are accounted for the in cache iterator');
@@ -117,7 +117,7 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getTestPool();
 
         $stash = $pool->getItem('base', 'one');
-        $stash->set($this->data);
+        $stash->set($this->data)->save();
         $this->assertTrue($pool->flush(), 'flush returns true');
 
         $stash = $pool->getItem('base', 'one');
@@ -130,7 +130,7 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getTestPool();
 
         $stash = $pool->getItem('base', 'one');
-        $stash->set($this->data, -600);
+        $stash->set($this->data, -600)->save();
         $this->assertTrue($pool->purge(), 'purge returns true');
 
         $stash = $pool->getItem('base', 'one');

--- a/tests/Stash/Test/AbstractPoolTest.php
+++ b/tests/Stash/Test/AbstractPoolTest.php
@@ -88,13 +88,13 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
         $item = $pool->getItem('This/Test//Fail');
     }
 
-    public function testGetItemIterator()
+    public function testgetItems()
     {
         $pool = $this->getTestPool();
 
         $keys = array_keys($this->multiData);
 
-        $cacheIterator = $pool->getItemIterator($keys);
+        $cacheIterator = $pool->getItems($keys);
         $keyData = $this->multiData;
         foreach ($cacheIterator as $stash) {
             $key = $stash->getKey();
@@ -104,7 +104,7 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertCount(0, $keyData, 'all keys are accounted for the in cache iterator');
 
-        $cacheIterator = $pool->getItemIterator($keys);
+        $cacheIterator = $pool->getItems($keys);
         foreach ($cacheIterator as $stash) {
             $key = $stash->getKey();
             $data = $stash->get($key);

--- a/tests/Stash/Test/AbstractPoolTest.php
+++ b/tests/Stash/Test/AbstractPoolTest.php
@@ -130,7 +130,7 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getTestPool();
 
         $stash = $pool->getItem('base', 'one');
-        $stash->set($this->data, -600)->save();
+        $stash->set($this->data)->expiresAfter(-600)->save();
         $this->assertTrue($pool->purge(), 'purge returns true');
 
         $stash = $pool->getItem('base', 'one');

--- a/tests/Stash/Test/CacheExceptionTest.php
+++ b/tests/Stash/Test/CacheExceptionTest.php
@@ -31,7 +31,7 @@ class CacheExceptionTest extends \PHPUnit_Framework_TestCase
         $item->setKey(array('path', 'to', 'store'));
 
         $this->assertFalse($item->isDisabled());
-        $this->assertFalse($item->set(array(1, 2, 3), 3600));
+        $this->assertFalse($item->set(array(1, 2, 3), 3600)->save());
         $this->assertTrue($item->isDisabled(), 'Is disabled after exception is thrown in driver');
     }
 

--- a/tests/Stash/Test/Driver/EphemeralTest.php
+++ b/tests/Stash/Test/Driver/EphemeralTest.php
@@ -31,7 +31,7 @@ class EphemeralTest extends AbstractDriverTest
         $item1 = new Item();
         $item1->setPool($poolStub);
         $item1->setKey(array('##', '#'));
-        $item1->set('X'->save());
+        $item1->set('X')->save();
 
         $item2 = new Item();
         $item2->setPool($poolStub);

--- a/tests/Stash/Test/Driver/EphemeralTest.php
+++ b/tests/Stash/Test/Driver/EphemeralTest.php
@@ -31,12 +31,12 @@ class EphemeralTest extends AbstractDriverTest
         $item1 = new Item();
         $item1->setPool($poolStub);
         $item1->setKey(array('##', '#'));
-        $item1->set('X');
+        $item1->set('X'->save());
 
         $item2 = new Item();
         $item2->setPool($poolStub);
         $item2->setKey(array('#', '##'));
-        $item2->set('Y');
+        $item2->set('Y')->save();
 
         $this->assertEquals('X', $item1->get());
     }

--- a/tests/Stash/Test/Driver/FileSystemTest.php
+++ b/tests/Stash/Test/Driver/FileSystemTest.php
@@ -75,7 +75,7 @@ class FileSystemTest extends AbstractDriverTest
             $poolStub->setDriver($driver);
             $item->setPool($poolStub);
             $item->setKey($paths);
-            $item->set($rand);
+            $item->set($rand)->save();
 
             $allpaths = array_merge(array('cache'), $paths);
             $predicted = sys_get_temp_dir().

--- a/tests/Stash/Test/Driver/MemcacheAnyTest.php
+++ b/tests/Stash/Test/Driver/MemcacheAnyTest.php
@@ -59,6 +59,6 @@ class MemcacheAnyTest extends \PHPUnit_Framework_TestCase
         $item->setPool($poolStub);
 
         $item->setKey($key);
-        $this->assertTrue($item->set($key), 'Able to load and store with unconfigured extension.');
+        $this->assertTrue($item->set($key)->save(), 'Able to load and store with unconfigured extension.');
     }
 }

--- a/tests/Stash/Test/Driver/MemcacheTest.php
+++ b/tests/Stash/Test/Driver/MemcacheTest.php
@@ -78,7 +78,7 @@ class MemcacheTest extends AbstractDriverTest
         $item->setPool($poolStub);
         $item->setKey($key);
 
-        $this->assertTrue($item->set($key), 'Able to load and store memcache driver using multiple servers');
+        $this->assertTrue($item->set($key)->save(), 'Able to load and store memcache driver using multiple servers');
 
         $options = array();
         $options['extension'] = $this->extension;
@@ -89,6 +89,6 @@ class MemcacheTest extends AbstractDriverTest
         $poolStub->setDriver($driver);
         $item->setPool($poolStub);
         $item->setKey($key);
-        $this->assertTrue($item->set($key), 'Able to load and store memcache driver using default server');
+        $this->assertTrue($item->set($key)->save(), 'Able to load and store memcache driver using default server');
     }
 }

--- a/tests/Stash/Test/Driver/SqliteAnyTest.php
+++ b/tests/Stash/Test/Driver/SqliteAnyTest.php
@@ -47,7 +47,7 @@ class SqliteAnyTest extends \PHPUnit_Framework_TestCase
         $poolSub->setDriver($driver);
         $item->setPool($poolSub);
         $item->setKey($key);
-        $this->assertTrue($item->set($key), 'Able to load and store with unconfigured extension.');
+        $this->assertTrue($item->set($key)->save(), 'Able to load and store with unconfigured extension.');
     }
 
     public static function tearDownAfterClass()

--- a/tests/Stash/Test/ItemLoggerTest.php
+++ b/tests/Stash/Test/ItemLoggerTest.php
@@ -75,7 +75,7 @@ class ItemLoggerTest extends \PHPUnit_Framework_TestCase
         $item->setLogger($logger);
 
         // triggerlogging
-        $item->set('test_key');
+        $item->set('test_key')->save();
 
         $this->assertInstanceOf('Stash\Test\Exception\TestException',
                                 $logger->lastContext['exception'], 'Logger was passed exception in event context.');

--- a/tests/Stash/Test/PoolNamespaceTest.php
+++ b/tests/Stash/Test/PoolNamespaceTest.php
@@ -36,17 +36,17 @@ class PoolNamespaceTest extends AbstractPoolTest
 
         // No Namespace
         $item = $pool->getItem(array('base', 'one'));
-        $item->set($this->data);
+        $item->set($this->data)->save();
 
         // TestNamespace
         $pool->setNamespace('TestNamespace');
         $item = $pool->getItem(array('test', 'one'));
-        $item->set($this->data);
+        $item->set($this->data)->save();
 
         // TestNamespace2
         $pool->setNamespace('TestNamespace2');
         $item = $pool->getItem(array('test', 'one'));
-        $item->set($this->data);
+        $item->set($this->data)->save();
 
         // Flush TestNamespace
         $pool->setNamespace('TestNamespace');

--- a/tests/Stash/Test/Stubs/PoolGetDriverStub.php
+++ b/tests/Stash/Test/Stubs/PoolGetDriverStub.php
@@ -72,4 +72,25 @@ class PoolGetDriverStub implements PoolInterface
     {
         return false;
     }
+
+    public function commit()
+    {
+        return false;
+    }
+
+    public function saveDeferred($item)
+    {
+        return false;
+    }
+
+    public function save($item)
+    {
+        return false;
+    }
+
+    public function deleteItems(array $keys)
+    {
+        return false;
+    }
+
 }

--- a/tests/Stash/Test/Stubs/PoolGetDriverStub.php
+++ b/tests/Stash/Test/Stubs/PoolGetDriverStub.php
@@ -43,7 +43,7 @@ class PoolGetDriverStub implements PoolInterface
         return false;
     }
 
-    public function getItemIterator($keys)
+    public function getItems($keys)
     {
         return false;
     }

--- a/tests/Stash/Test/Stubs/PoolGetDriverStub.php
+++ b/tests/Stash/Test/Stubs/PoolGetDriverStub.php
@@ -92,5 +92,4 @@ class PoolGetDriverStub implements PoolInterface
     {
         return false;
     }
-
 }

--- a/tests/Stash/Test/Stubs/PoolGetDriverStub.php
+++ b/tests/Stash/Test/Stubs/PoolGetDriverStub.php
@@ -73,6 +73,11 @@ class PoolGetDriverStub implements PoolInterface
         return false;
     }
 
+    public function exists($key)
+    {
+        return false;
+    }
+
     public function commit()
     {
         return false;


### PR DESCRIPTION
The goal behind this branch is to bring Stash current with PSR6 as it currently stands. These changes are mostly cosmetic API changes but sometimes stretch further than that. This will *not* be a backwards compatible branch.

- [x] Update API to match PSR6 and update test suite accordingly.
- [x] Write tests for all new functions.
- [x] Follow exception guidelines.
- [x] Review all return values to make sure they match the proposed standard.
- [x] Document Interface changes.
- [x] Update Changelog.
