### PR TITLE
Fix non informative exception text

### DIFF
--- a/src/Stash/Driver/AbstractDriver.php
+++ b/src/Stash/Driver/AbstractDriver.php
@@ -33,7 +33,7 @@ abstract class AbstractDriver implements DriverInterface
     public function __construct(array $options = array())
     {
         if (!static::isAvailable()) {
-            throw new RuntimeException(__CLASS__ . ' is not available.');
+            throw new RuntimeException(get_class($this) . ' is not available.');
         }
 
         $this->setOptions($options);


### PR DESCRIPTION
Error always throw `Stash\Driver\AbstractDriver is not available` insead of point what dirver not allowed.