### PR TITLE
Added Item::want() method

### DIFF
--- a/src/Stash/Interfaces/ItemInterface.php
+++ b/src/Stash/Interfaces/ItemInterface.php
@@ -71,6 +71,20 @@ interface ItemInterface
     public function get($invalidation = 0, $arg = null, $arg2 = null);
 
     /**
+     * Returns the data retrieved from the cache if possible. If a cache miss
+     * occurs, this method uses the generator callback to generate the data
+     * which it then automatically sets. The generator callback takes no
+     * parameters.
+     *
+     * @param  callable   $generator
+     * @param  int        $invalidation
+     * @param  null       $arg
+     * @param  null       $arg2
+     * @return mixed|null
+     */
+    public function want($generator, $invalidation = 0, $arg = null, $arg2 = null);
+
+    /**
      * Returns true if the cached item needs to be refreshed.
      *
      * @return bool

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -231,6 +231,24 @@ class Item implements ItemInterface
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function want($generator, $invalidation = Invalidation::PRECOMPUTE, $arg = null, $arg2 = null)
+    {
+        $data = $this->get($invalidation, $arg, $arg2);
+
+        if ($this->isMiss()) {
+            $this->lock();
+
+            $data = $generator();
+
+            $this->set($data);
+        }
+
+        return $data;
+    }
+
     private function executeGet($invalidation, $arg, $arg2)
     {
         $this->isHit = false;

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -152,6 +152,28 @@ abstract class AbstractItemTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @depends testGet
+     */
+    public function testWant()
+    {
+        $failGenerator = function () { $this->fail('Generator should not be called'); };
+
+        foreach ($this->data as $type => $value) {
+            $valueGenerator = function () use ($value) { return $value; };
+
+            $key = array('base', $type);
+            $stash = $this->testConstruct($key);
+            $data = $stash->want($valueGenerator);
+            $this->assertEquals($value, $data, 'want ' . $type . ' generates item');
+
+            // new object, but same backend
+            $stash = $this->testConstruct($key);
+            $data = $stash->want($failGenerator);
+            $this->assertEquals($value, $data, 'want ' . $type . ' uses previously generated value');
+        }
+    }
+
+    /**
      * @expectedException PHPUnit_Framework_Error
      * @expectedExceptionMessage Argument 1 passed to Stash\Item::setKey()
      */


### PR DESCRIPTION
This is a feature that I included on some cache wrappers that I've written before and thought it might be useful for Stash.

The general idea is that instead of doing:

```php
$data = $item->get();

if ($item->isMiss()) {
    $item->lock();

    $data = codeThatTakesALongTime();

    $item->set($data);
}
```

You can do:

```php
$data = $item->want('codeThatTakesALongTime');
```

I'm not sure on the name. I used 'Item::want()' to try to convey that it is similar to 'Item::get()', but more definitive.

Also not sure on expected behaviour handling exceptions. My instinct is to let errors fall through, but I'm not sure if they should be logged with 'Item::logException()' and then thrown again.

Also not sure on whether the callback should be passed any parameters or not.

Interested to hear your thoughts.

@tedivm 


