### PR TITLE
Remove call to Utilities::getBaseDirectory unless path option is not passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Stash v0.13 Changelog
 
+
+### 0.13.2
+
+* Fixed bug where the default filesystem driver path would be created even when a path was specified.
+
 ### 0.13.1
 
 * Dropped support for PHP 5.3.

--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -114,7 +114,6 @@ class FileSystem extends AbstractDriver
     public function getDefaultOptions()
     {
         return array(
-            'path' => Utilities::getBaseDirectory($this),
             'filePermissions' => 0660,
             'dirPermissions' => 0770,
             'dirSplit' => 2,
@@ -133,6 +132,9 @@ class FileSystem extends AbstractDriver
     public function setOptions(array $options = array())
     {
         $options += $this->getDefaultOptions();
+        if (!isset($options['path'])) {
+            $options['path'] = Utilities::getBaseDirectory($this);
+        }
 
         $this->cachePath = rtrim($options['path'], '\\/') . DIRECTORY_SEPARATOR;
         $this->filePermissions = $options['filePermissions'];


### PR DESCRIPTION
This should resolve #263.