### PR TITLE
Update coveralls configuration

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,2 @@
-src_dir: src
 coverage_clover: build/logs/clover.xml
 json_path: build/logs/coveralls-upload.json


### PR DESCRIPTION
The coveralls configuration has changed, resulting in an exception being thrown and updated line counts not being sent. This update fixes that.