### PR TITLE
Installation instructions with composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ review changes before Minor updates, although bug fixes will always be
 backwards compatible.
 
 ```
-"require": {
-  "tedivm/stash": "0.14.*"
-}
+composer require tedivm/stash
 ```
 
 ### Github


### PR DESCRIPTION
Composer will figure out current stable version and set constraint to `^0.14.0` and not upgrade to 0.15, ever. Unless instructed.