### PR TITLE
Incorrect case of namespace

### DIFF
--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -11,7 +11,7 @@
 
 namespace Stash;
 
-use PSR\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemInterface;
 use Stash\Exception\InvalidArgumentException;
 use Stash\Driver\Ephemeral;
 use Stash\Interfaces\DriverInterface;


### PR DESCRIPTION
Incorrect case of namespace will cause some issues with autoloading and case-sensitive file systems