### PR TITLE
Memcached persistent connection.

### DIFF
--- a/tests/Stash/Test/Driver/Sub/MemcachedTest.php
+++ b/tests/Stash/Test/Driver/Sub/MemcachedTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash\Test\Driver\Sub;
+
+use Stash\Test\Stubs\MemcachedStub;
+
+class MemcachedTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstruction()
+    {
+        $options = array(
+            'servers' => array(
+                '127.0.0.1:1121',
+                '127.0.0.2:1121',
+            ),
+
+            'HASH' => 'MD5',
+            'distribution' => 'CONSISTENT',
+            'SERIALIZER' => 'PHP',
+            'SEND_TIMEOUT' => 100,
+            'PREFIX_KEY' => 'prefix',
+            'SOCKET_SEND_SIZE' => 123,
+            'SOCKET_RECV_SIZE' => 123,
+            'CONNECT_TIMEOUT' => 123,
+            'RETRY_TIMEOUT' => 123,
+            'RECV_TIMEOUT' => 123,
+            'POLL_TIMEOUT' => 123,
+            'SERVER_FAILURE_LIMIT' => 123,
+            'COMPRESSION' => true,
+            'LIBKETAMA_COMPATIBLE' => true,
+            'BUFFER_WRITES' => true,
+            'BINARY_PROTOCOL' => true,
+            'NO_BLOCK' => true,
+            'TCP_NODELAY' => true,
+            'CACHE_LOOKUPS' => true,
+        );
+
+        $servers = array(
+            array('127.0.0.1', 1121, null),
+            array('127.0.0.2', 1121, null),
+        );
+
+        $subMemcached = $this->getMockBuilder('Stash\Driver\Sub\Memcached')
+                             ->setMethods(array('newMemcachedInstance'))
+                             ->disableOriginalConstructor()
+                             ->getMock();
+
+        $memcachedStub = new MemcachedStub(true, true);
+        $subMemcached->expects($this->once())
+                     ->method('newMemcachedInstance')
+                     ->willReturn($memcachedStub);
+
+
+        $reflection = new \ReflectionClass('Stash\Driver\Sub\Memcached');
+        $constructor = $reflection->getConstructor();
+        $constructor->invoke($subMemcached, $servers, $options);
+
+        $this->assertEquals(
+            array(
+                \Memcached::OPT_HASH => \Memcached::HASH_MD5,
+                \Memcached::OPT_DISTRIBUTION => \Memcached::DISTRIBUTION_CONSISTENT,
+                \Memcached::OPT_SERIALIZER => \Memcached::SERIALIZER_PHP,
+                \Memcached::OPT_SEND_TIMEOUT => 100,
+                \Memcached::OPT_PREFIX_KEY => 'prefix',
+                \Memcached::OPT_SOCKET_SEND_SIZE => 123,
+                \Memcached::OPT_SOCKET_RECV_SIZE => 123,
+                \Memcached::OPT_CONNECT_TIMEOUT => 123,
+                \Memcached::OPT_RETRY_TIMEOUT => 123,
+                \Memcached::OPT_RECV_TIMEOUT => 123,
+                \Memcached::OPT_POLL_TIMEOUT => 123,
+                \Memcached::OPT_SERVER_FAILURE_LIMIT => 123,
+                \Memcached::OPT_COMPRESSION => true,
+                \Memcached::OPT_LIBKETAMA_COMPATIBLE => true,
+                \Memcached::OPT_BUFFER_WRITES => true,
+                \Memcached::OPT_BINARY_PROTOCOL => true,
+                \Memcached::OPT_NO_BLOCK => true,
+                \Memcached::OPT_TCP_NODELAY => true,
+                \Memcached::OPT_CACHE_LOOKUPS =>true,
+            ),
+            $memcachedStub->getOptions()
+        );
+
+        $this->assertEquals(
+            array(
+                array('127.0.0.1', 1121, null),
+                array('127.0.0.2', 1121, null),
+            ),
+            $memcachedStub->getServerList()
+        );
+    }
+}

--- a/tests/Stash/Test/Stubs/MemcachedStub.php
+++ b/tests/Stash/Test/Stubs/MemcachedStub.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash\Test\Stubs;
+
+use Stash;
+
+class MemcachedStub extends \Memcached
+{
+    protected $options = [];
+    protected $servers = [];
+
+    public function __construct($isPersistent, $pristine)
+    {
+        // disable original constructor
+    }
+
+    public function addServer($host, $port, $weight = 0)
+    {
+        $this->addServers(array(array($host, $port, $weight)));
+        return true;
+    }
+
+    public function addServers(array $servers)
+    {
+        $this->servers += $servers;
+        return true;
+    }
+
+    public function getServerList()
+    {
+        return $this->servers;
+    }
+
+    public function setOptions($options)
+    {
+        $this->options = $options;
+        return true;
+    }
+
+    public function setOption($name, $value)
+    {
+        $this->options[$name] = $value;
+        return true;
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
+}


### PR DESCRIPTION
Memcache (without "d") connections are persistent by defautl.
In order to save resources (new TCP/IP sockets for each HTTP requests) for both backends I propose to make Memcached connections to be persistent by default.
To keep configuration easy and clean `persist_id` is calculated automatically based on servers list and options array (any change to options will cause `persist_id` change).
#313 Can be resolved by this pull request.
