### PR TITLE
Add predis support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
   "require-dev": {
     "fabpot/php-cs-fixer": "^1.9",
     "phpunit/phpunit": "4.8.*",
-    "satooshi/php-coveralls": "1.0.*"
+    "satooshi/php-coveralls": "1.0.*",
+    "predis/predis": "^1.1"
   },
   "autoload": {
     "psr-4": {

--- a/src/Stash/Driver/FileSystem/NativeEncoder.php
+++ b/src/Stash/Driver/FileSystem/NativeEncoder.php
@@ -97,7 +97,7 @@ class NativeEncoder implements EncoderInterface
                 $dataString = (string) $data;
                 break;
 
-            default :
+            default:
                 case 'serialize':
                     $dataString = 'unserialize(base64_decode(\'' . base64_encode(serialize($data)) . '\'))';
                     break;

--- a/src/Stash/Driver/Sub/Predis.php
+++ b/src/Stash/Driver/Sub/Predis.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash\Driver\Sub;
+
+use Predis\Connection\AggregateConnectionInterface;
+
+class Predis
+{
+    protected $predis;
+
+    public function __construct(array $servers, array $options = array())
+    {
+        $predisServers = array();
+
+        foreach ($servers as $server) {
+            if (isset($server['socket']) && $server['socket']) {
+                $s = array(
+                    'scheme' => 'unix',
+                    'path'   => $server['socket'],
+                );
+            } else {
+                $s = array(
+                    'scheme'  => 'tcp',
+                    'host'    => $server['server'],
+                    'port'    => isset($server['port']) ? $server['port'] : 6379,
+                    'timeout' => isset($server['ttl']) ? $server['ttl'] : 0.1,
+                );
+            }
+
+            // auth - just password
+            if (isset($options['password'])) {
+                $s['password'] = $options['password'];
+            }
+
+            if (isset($options['database'])) {
+                $s['database'] = $options['database'];
+            }
+
+            $predisServers[] = $s;
+        }
+
+        if (count($predisServers) == 1) {
+            $predisServers = $predisServers[0];
+        }
+
+        $this->predis = new \Predis\Client($predisServers);
+    }
+
+    /**
+     * Properly close the connection.
+     */
+    public function close()
+    {
+        $this->predis->disconnect();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($key)
+    {
+        return $this->predis->get($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($key, $data)
+    {
+        return $this->predis->set($key, $data);
+    }
+
+    public function setex($key, $ttl, $data)
+    {
+        return $this->predis->setex($key, $ttl, $data) == 'OK';
+    }
+
+    public function incr($key)
+    {
+        return $this->predis->incr($key);
+    }
+
+    public function delete($key)
+    {
+        return $this->predis->del($key);
+    }
+
+    public function flushDB()
+    {
+        if ($this->predis->getConnection() instanceof AggregateConnectionInterface) {
+            foreach ($this->predis as $conn) {
+                $conn->flushdb();
+            }
+            return true;
+        } else {
+            return $this->predis->flushdb();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function isAvailable()
+    {
+        return class_exists('Predis\\Client');
+    }
+}

--- a/src/Stash/Driver/Sub/Redis.php
+++ b/src/Stash/Driver/Sub/Redis.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash\Driver\Sub;
+
+class Redis
+{
+    protected $redis;
+
+    protected $redisArrayOptionNames = array(
+        "previous",
+        "function",
+        "distributor",
+        "index",
+        "autorehash",
+        "pconnect",
+        "retry_interval",
+        "lazy_connect",
+        "connect_timeout",
+    );
+
+    public function __construct(array $servers, array $options = array())
+    {
+        // this will have to be revisited to support multiple servers, using
+        // the RedisArray object. That object acts as a proxy object, meaning
+        // most of the class will be the same even after the changes.
+
+        if (count($servers) == 1) {
+            $server = $servers[0];
+            $redis = new \Redis();
+
+            if (isset($server['socket']) && $server['socket']) {
+                $redis->connect($server['socket']);
+            } else {
+                $port = isset($server['port']) ? $server['port'] : 6379;
+                $ttl = isset($server['ttl']) ? $server['ttl'] : 0.1;
+                $redis->connect($server['server'], $port, $ttl);
+            }
+
+            // auth - just password
+            if (isset($options['password'])) {
+                $redis->auth($options['password']);
+            }
+
+            $this->redis = $redis;
+        } else {
+            $redisArrayOptions = array();
+            foreach ($this->redisArrayOptionNames as $optionName) {
+                if (array_key_exists($optionName, $options)) {
+                    $redisArrayOptions[$optionName] = $options[$optionName];
+                }
+            }
+
+            $serverArray = array();
+            foreach ($servers as $server) {
+                $serverString = $server['server'];
+                if (isset($server['port'])) {
+                    $serverString .= ':' . $server['port'];
+                }
+
+                $serverArray[] = $serverString;
+            }
+
+            $redis = new \RedisArray($serverArray, $redisArrayOptions);
+        }
+
+        // select database
+        if (isset($options['database'])) {
+            $redis->select($options['database']);
+        }
+
+        $this->redis = $redis;
+    }
+
+    /**
+     * Properly close the connection.
+     */
+    public function close()
+    {
+        if ($this->redis instanceof \Redis) {
+            try {
+                $this->redis->close();
+            } catch (\RedisException $e) {
+                /*
+                 * \Redis::close will throw a \RedisException("Redis server went away") exception if
+                 * we haven't previously been able to connect to Redis or the connection has severed.
+                 */
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($key)
+    {
+        return $this->redis->get($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($key, $data)
+    {
+        return $this->redis->set($key, $data);
+    }
+
+    public function setex($key, $ttl, $data)
+    {
+        return $this->redis->setex($key, $ttl, $data);
+    }
+
+    public function incr($key)
+    {
+        return $this->redis->incr($key);
+    }
+
+    public function delete($key)
+    {
+        return $this->redis->delete($key);
+    }
+
+    public function flushDB()
+    {
+        return $this->redis->flushDB();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function isAvailable()
+    {
+        return class_exists('Redis', false);
+    }
+}

--- a/tests/Stash/Test/Driver/PredisClusterTest.php
+++ b/tests/Stash/Test/Driver/PredisClusterTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash\Test\Driver;
+
+class PredisClusterTest extends RedisTest
+{
+    protected $extension = 'predis';
+    protected $driverClass = 'Stash\Driver\Redis';
+
+    protected $redisSecondServer = '127.0.0.1';
+    protected $redisSecondPort = '6380';
+    protected $persistence = true;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (!($sock = @fsockopen($this->redisServer, $this->redisPort, $errno, $errstr, 1))) {
+            $this->markTestSkipped('Redis server unavailable for testing.');
+        }
+        fclose($sock);
+
+        if (!($sock = @fsockopen($this->redisSecondServer, $this->redisSecondPort, $errno, $errstr, 1))) {
+            $this->markTestSkipped('Second Redis Server needed for more tests.');
+        }
+        fclose($sock);
+    }
+
+    protected function getOptions()
+    {
+        return array(
+            'extension' => $this->extension,
+            'servers' => array(
+                array('server' => $this->redisServer, 'port' => $this->redisPort, 'ttl' => 0.1),
+                array('server' => $this->redisSecondServer, 'port' => $this->redisSecondPort, 'ttl' => 0.1),
+            ),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldConstructAPredisAggregate()
+    {
+        $driver = $this->getFreshDriver();
+        $class = new \ReflectionClass($driver);
+        $redisProperty = $class->getProperty('redis');
+        $redisProperty->setAccessible(true);
+        $redisImpl = $redisProperty->getValue($driver);
+
+        $class = new \ReflectionClass($redisImpl);
+        $redisProperty = $class->getProperty('predis');
+        $redisProperty->setAccessible(true);
+        $predis = $redisProperty->getValue($redisImpl);
+
+        $this->assertInstanceOf('\Predis\Connection\Aggregate\PredisCluster', $predis->getConnection());
+    }
+}

--- a/tests/Stash/Test/Driver/PredisSocketTest.php
+++ b/tests/Stash/Test/Driver/PredisSocketTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash\Test\Driver;
+
+/**
+ * @package Stash
+ * @author  Robert Hafner <tedivm@tedivm.com>
+ */
+class PredisSocketTest extends RedisTest
+{
+    protected function getOptions()
+    {
+        $socket = '/tmp/redis.sock';
+
+        return array(
+            'extension' => 'predis',
+            'servers' => array(
+                array('socket' => $socket, 'ttl' => 0.1)
+            )
+        );
+    }
+}

--- a/tests/Stash/Test/Driver/PredisTest.php
+++ b/tests/Stash/Test/Driver/PredisTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash\Test\Driver;
+
+/**
+ * @package Stash
+ * @author  Robert Hafner <tedivm@tedivm.com>
+ */
+class PredisTest extends RedisTest
+{
+    protected $extension = 'predis';
+}

--- a/tests/Stash/Test/Driver/RedisAnyTest.php
+++ b/tests/Stash/Test/Driver/RedisAnyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash\Test\Driver;
+
+use Stash\Test\Stubs\PoolGetDriverStub;
+use Stash\Driver\Redis;
+use Stash\Item;
+
+/**
+ * @package Stash
+ * @author  Robert Hafner <tedivm@tedivm.com>
+ */
+class RedisAnyTest extends \PHPUnit_Framework_TestCase
+{
+    protected $driverClass = 'Stash\Driver\Redis';
+
+    protected $redisServer = '127.0.0.1';
+    protected $redisPort = '6379';
+
+    protected function setUp()
+    {
+        $driverClass = $this->driverClass;
+
+        if (!$driverClass::isAvailable()) {
+            $this->markTestSkipped('Driver class unsuited for current environment');
+
+            return;
+        }
+
+        if (!($sock = @fsockopen($this->redisServer, $this->redisPort, $errno, $errstr, 1))) {
+            $this->markTestSkipped('Redis tests require redis server');
+
+            return;
+        }
+
+        fclose($sock);
+    }
+
+    public function testConstruction()
+    {
+        $key = array('apple', 'sauce');
+
+        $options = array(
+            'servers' => array(
+                array('server' => $this->redisServer, 'port' => $this->redisPort, 'ttl' => 0.1)
+            ),
+        );
+        $driver = new Redis($options);
+
+        $item = new Item();
+        $poolStub = new PoolGetDriverStub();
+        $poolStub->setDriver($driver);
+        $item->setPool($poolStub);
+
+        $item->setKey($key);
+        $this->assertTrue($item->set($key)->save(), 'Able to load and store with unconfigured extension.');
+    }
+}

--- a/tests/Stash/Test/Driver/RedisArrayTest.php
+++ b/tests/Stash/Test/Driver/RedisArrayTest.php
@@ -45,6 +45,7 @@ class RedisArrayTest extends RedisTest
     protected function getOptions()
     {
         return array(
+            'extension' => $this->extension,
             'servers' => array(
                 array('server' => $this->redisServer, 'port' => $this->redisPort, 'ttl' => 0.1),
                 array('server' => $this->redisSecondServer, 'port' => $this->redisSecondPort, 'ttl' => 0.1),
@@ -61,7 +62,12 @@ class RedisArrayTest extends RedisTest
         $class = new \ReflectionClass($driver);
         $redisProperty = $class->getProperty('redis');
         $redisProperty->setAccessible(true);
-        $redisArray = $redisProperty->getValue($driver);
+        $redisImpl = $redisProperty->getValue($driver);
+
+        $class = new \ReflectionClass($redisImpl);
+        $redisProperty = $class->getProperty('redis');
+        $redisProperty->setAccessible(true);
+        $redisArray = $redisProperty->getValue($redisImpl);
 
         $this->assertInstanceOf('\RedisArray', $redisArray);
     }

--- a/tests/Stash/Test/Driver/RedisArrayTest.php
+++ b/tests/Stash/Test/Driver/RedisArrayTest.php
@@ -79,8 +79,12 @@ class RedisArrayTest extends RedisTest
     {
         $redisArrayOptions = array(
             "previous"        => "something",
-            "function"        => function ($key) { return $key; },
-            "distributor"     => function ($key) { return 0; },
+            "function"        => function ($key) {
+                return $key;
+            },
+            "distributor"     => function ($key) {
+                return 0;
+            },
             "index"           => "something",
             "autorehash"      => "something",
             "pconnect"        => "something",

--- a/tests/Stash/Test/Driver/RedisTest.php
+++ b/tests/Stash/Test/Driver/RedisTest.php
@@ -17,6 +17,7 @@ namespace Stash\Test\Driver;
  */
 class RedisTest extends AbstractDriverTest
 {
+    protected $extension = 'redis';
     protected $driverClass = 'Stash\Driver\Redis';
     protected $redisServer = '127.0.0.1';
     protected $redisPort = '6379';
@@ -53,16 +54,22 @@ class RedisTest extends AbstractDriverTest
 
     protected function getOptions()
     {
-        return array('servers' => array(
-            array('server' => $this->redisServer, 'port' => $this->redisPort, 'ttl' => 0.1)
-        ));
+        return array(
+            'extension' => $this->extension,
+            'servers' => array(
+                array('server' => $this->redisServer, 'port' => $this->redisPort, 'ttl' => 0.1)
+            ),
+        );
     }
 
     protected function getInvalidOptions()
     {
-        return array('servers' => array(
-            array('server' => $this->redisNoServer, 'port' => $this->redisNoPort, 'ttl' => 0.1)
-        ));
+        return array(
+            'extension' => $this->extension,
+            'servers' => array(
+                array('server' => $this->redisNoServer, 'port' => $this->redisNoPort, 'ttl' => 0.1)
+            ),
+        );
     }
 
     public function testBadDisconnect()


### PR DESCRIPTION
This is another attempt to add support for the Predis driver. We really want to use Stash on our current project but for various political reasons we cannot deploy phpredis to our production environment.

I saw two previous attempts to add predis. #270 was in part rejected because it did not abstract away the switchable backend implementation. #311 was not completed but also did not attempt to do this.

This merge changes the Redis driver to be modeled after the Memcache driver and allows for specification of the implementation via the _extension_ option. If not specified, the driver prefers phpredis over predis.

This merge also includes mostly complete tests for both implementations (again modeled after the equivalents for Memcache).

There is an attempt to support Predis multi-server, but I am not familiar enough with how it should work to write an effective test for this.
