### PR TITLE
Skip redis socket test if socket doesn’t exist

### DIFF
--- a/src/Stash/Driver/FileSystem/NativeEncoder.php
+++ b/src/Stash/Driver/FileSystem/NativeEncoder.php
@@ -97,7 +97,7 @@ class NativeEncoder implements EncoderInterface
                 $dataString = (string) $data;
                 break;
 
-            default :
+            default:
                 case 'serialize':
                     $dataString = 'unserialize(base64_decode(\'' . base64_encode(serialize($data)) . '\'))';
                     break;

--- a/tests/Stash/Test/Driver/RedisArrayTest.php
+++ b/tests/Stash/Test/Driver/RedisArrayTest.php
@@ -73,8 +73,12 @@ class RedisArrayTest extends RedisTest
     {
         $redisArrayOptions = array(
             "previous"        => "something",
-            "function"        => function ($key) { return $key; },
-            "distributor"     => function ($key) { return 0; },
+            "function"        => function ($key) {
+                return $key;
+            },
+            "distributor"     => function ($key) {
+                return 0;
+            },
             "index"           => "something",
             "autorehash"      => "something",
             "pconnect"        => "something",

--- a/tests/Stash/Test/Driver/RedisSocketTest.php
+++ b/tests/Stash/Test/Driver/RedisSocketTest.php
@@ -21,6 +21,10 @@ class RedisSocketTest extends RedisTest
     {
         $socket = '/tmp/redis.sock';
 
+        if(!file_exists($socket)) {
+            $this->markTestSkipped("Redis socket not installed");
+        }
+
         return array('servers' => array(
             array('socket' => $socket, 'ttl' => 0.1)
         ));

--- a/tests/Stash/Test/Driver/RedisSocketTest.php
+++ b/tests/Stash/Test/Driver/RedisSocketTest.php
@@ -17,16 +17,6 @@ namespace Stash\Test\Driver;
  */
 class RedisSocketTest extends RedisTest
 {
-    protected function setUp()
-    {
-        if (!$this->setup) {
-            if (!($sock = @fsockopen('/tmp/redis.sock', null, $errno, $errstr, 1))) {
-                $this->markTestSkipped('Redis server unavailable for testing.');
-            }
-            fclose($sock);
-        }
-    }
-
     protected function getOptions()
     {
         $socket = '/tmp/redis.sock';


### PR DESCRIPTION
Locally, (using mac with homebrew) I do not have a sock file in `/tmp/redis.sock` so this checks if there exists a file there, if there doesn't then it skips the test.

if there is a better way to check this, let me know and i'll change it appropriately.