### PR TITLE
Added an ability to set default invalidation method for a pool

### DIFF
--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -63,6 +63,10 @@ class Pool implements PoolInterface
      */
     protected $namespace;
 
+    protected $invalidationMethod = Invalidation::PRECOMPUTE;
+    protected $invalidationArg1 = null;
+    protected $invalidationArg2 = null;
+
     /**
      * The constructor takes a Driver class which is used for persistent
      * storage. If no driver is provided then the Ephemeral driver is used by
@@ -120,6 +124,7 @@ class Pool implements PoolInterface
         $item = new $this->itemClass();
         $item->setPool($this);
         $item->setKey($key, $namespace);
+        $item->setInvalidationMethod($this->invalidationMethod, $this->invalidationArg1, $this->invalidationArg2);
 
         if ($this->isDisabled) {
             $item->disable();
@@ -307,6 +312,22 @@ class Pool implements PoolInterface
         $this->logger = $logger;
 
         return true;
+    }
+
+    /**
+     * Set the default cache invalidation method for items created by this pool object.
+     *
+     * @see Stash\Invalidation
+     *
+     * @param int   $invalidation A Stash\Invalidation constant
+     * @param mixed $arg          First argument for invalidation method
+     * @param mixed $arg2         Second argument for invalidation method
+     */
+    public function setInvalidationMethod($invalidation = Invalidation::PRECOMPUTE, $arg = null, $arg2 = null)
+    {
+        $this->invalidationMethod = $invalidation;
+        $this->invalidationArg1 = $arg;
+        $this->invalidationArg2 = $arg2;
     }
 
     /**

--- a/tests/Stash/Test/AbstractPoolTest.php
+++ b/tests/Stash/Test/AbstractPoolTest.php
@@ -12,6 +12,7 @@
 namespace Stash\Test;
 
 use Stash\Exception\InvalidArgumentException;
+use Stash\Invalidation;
 use Stash\Pool;
 use Stash\Driver\Ephemeral;
 use Stash\Test\Stubs\LoggerStub;
@@ -340,6 +341,18 @@ class AbstractPoolTest extends \PHPUnit_Framework_TestCase
             $logger->lastContext['exception'], 'Logger was passed exception in event context.');
         $this->assertTrue(strlen($logger->lastMessage) > 0, 'Logger message set after "set" exception.');
         $this->assertEquals('critical', $logger->lastLevel, 'Exceptions logged as critical.');
+    }
+
+    public function testSetInvalidationMethod()
+    {
+        $pool = $this->getTestPool();
+
+        $pool->setInvalidationMethod(Invalidation::OLD, 'test1', 'test2');
+        $item = $pool->getItem('test/item');
+
+        $this->assertAttributeEquals(Invalidation::OLD, 'invalidationMethod', $item, 'Pool sets Item invalidation constant.');
+        $this->assertAttributeEquals('test1', 'invalidationArg1', $item, 'Pool sets Item invalidation argument 1.');
+        $this->assertAttributeEquals('test2', 'invalidationArg2', $item, 'Pool sets Item invalidation argument 2.');
     }
 
     /**


### PR DESCRIPTION
There is a new method `Pool::setInvalidationMethod` that sets default invalidation method for a `Pool` object. After this method call, all `Item` objects got from the pool use the pool default invalidation method.

The pull request closes #96