### PR TITLE
Added support for the 'remove_failed_servers' option of the memcached extension

### DIFF
--- a/src/Stash/Driver/Sub/Memcached.php
+++ b/src/Stash/Driver/Sub/Memcached.php
@@ -60,7 +60,8 @@ class Memcached
                             'POLL_TIMEOUT',
                             'CACHE_LOOKUPS',
                             'SERVER_FAILURE_LIMIT',
-                            'CLIENT_MODE'
+                            'CLIENT_MODE',
+                            'REMOVE_FAILED_SERVERS',
         );
 
         $memcached = new \Memcached();
@@ -128,6 +129,7 @@ class Memcached
                 case 'NO_BLOCK':
                 case 'TCP_NODELAY':
                 case 'CACHE_LOOKUPS':
+                case 'REMOVE_FAILED_SERVERS':
                     if (!is_bool($value)) {
                         throw new RuntimeException('Memcached option ' . $name . ' requires boolean value');
                     }


### PR DESCRIPTION
Adds support for `Memcached::OPT_REMOVE_FAILED_SERVERS`.