### PR TITLE
Allow DateTimeInterface in `executeSet`

### DIFF
--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -422,7 +422,7 @@ class Item implements ItemInterface
         $store['return'] = $data;
         $store['createdOn'] = time();
 
-        if (isset($time) && ($time instanceof \DateTime)) {
+        if (isset($time) && (($time instanceof \DateTime) || ($time instanceof \DateTimeInterface))) {
             $expiration = $time->getTimestamp();
             $cacheTime = $expiration - $store['createdOn'];
         } else {


### PR DESCRIPTION
When `$time`  is not `\DateTime` but implements `\DateTimeInterface` it is ignored and `self::$cacheTime` is used.