### PR TITLE
Fix Travis-CI redis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,5 @@ services:
 
 matrix:
     fast_finish: true
+
+sudo: required

--- a/tests/Stash/Test/Driver/RedisTest.php
+++ b/tests/Stash/Test/Driver/RedisTest.php
@@ -65,6 +65,9 @@ class RedisTest extends AbstractDriverTest
         ));
     }
 
+    /**
+     * @expectedException \PHPUnit_Framework_Error_Warning
+     */
     public function testBadDisconnect()
     {
         if (defined('HHVM_VERSION')) {


### PR DESCRIPTION
Add missing `@expectedException` to `testBadDisconnect()` test so expected warning raised by Redis::connect() wont break test.
Also added `sudo: required` to `.travis.yml` because it is not set by default on new repos, so forked repos like mine won't fail to build now.