### PR TITLE
Fixes #347

### DIFF
--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -321,6 +321,11 @@ class FileSystem extends AbstractDriver
     public function clear($key = null)
     {
         $path = $this->makePath($key);
+
+        if($key === null) {
+            return Utilities::deleteRecursive($path, false);
+        }
+
         if (is_file($path)) {
             $return = true;
             unlink($path);


### PR DESCRIPTION
FileSystem Driver - do not delete root cache directory while clear on entire pool.