### PR TITLE
Redis Driver - Delete subkeys on stackparent removal / optional key normalization

### DIFF
--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -12,6 +12,8 @@
 namespace Stash\Driver;
 
 use Stash;
+use Stash\Exception\InvalidArgumentException;
+use Stash\Utilities;
 
 /**
  * The Redis driver is used for storing data on a Redis system. This class uses
@@ -20,284 +22,366 @@ use Stash;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class Redis extends AbstractDriver
-{
+class Redis extends AbstractDriver {
+	const SERVER_DEFAULT_HOST = '127.0.0.1';
+	const SERVER_DEFAULT_PORT = 6379;
+	const SERVER_DEFAULT_TTL  = 0.1;
+	
 	protected static $pathPrefix = 'pathdb:';
 	
-    /**
-     * The Redis drivers.
-     *
-     * @var \Redis|\RedisArray
-     */
-    protected $redis;
-
-    /**
-     * The cache of indexed keys.
-     *
-     * @var array
-     */
-    protected $keyCache = array();
-
-    protected $redisArrayOptionNames = array(
-        "previous",
-        "function",
-        "distributor",
-        "index",
-        "autorehash",
-        "pconnect",
-        "retry_interval",
-        "lazy_connect",
-        "connect_timeout",
-    );
-
-    /**
-     * The options array should contain an array of servers,
-     *
-     * The "server" option expects an array of servers, with each server being represented by an associative array. Each
-     * redis config must have either a "socket" or a "server" value, and optional "port" and "ttl" values (with the ttl
-     * representing server timeout, not cache expiration).
-     *
-     * The "database" option lets developers specific which specific database to use.
-     *
-     * The "password" option is used for clusters which required authentication.
-     *
-     * @param array $options
-     */
-    protected function setOptions(array $options = array())
-    {
-        $options += $this->getDefaultOptions();
-
-        // Normalize Server Options
-        if (isset($options['servers'])) {
-            $unprocessedServers = (is_array($options['servers']))
-                ? $options['servers']
-                : array($options['servers']);
-            unset($options['servers']);
-
-            $servers = array();
-            foreach ($unprocessedServers as $server) {
-                $ttl = '.1';
-                if (isset($server['ttl'])) {
-                    $ttl = $server['ttl'];
-                } elseif (isset($server[2])) {
-                    $ttl = $server[2];
-                }
-
-                if (isset($server['socket'])) {
-                    $servers[] = array('socket' => $server['socket'], 'ttl' => $ttl);
-                } else {
-                    $host = '127.0.0.1';
-                    if (isset($server['server'])) {
-                        $host = $server['server'];
-                    } elseif (isset($server[0])) {
-                        $host = $server[0];
-                    }
-
-                    $port = '6379';
-                    if (isset($server['port'])) {
-                        $port = $server['port'];
-                    } elseif (isset($server[1])) {
-                        $port = $server[1];
-                    }
-
-                    $servers[] = array('server' => $host, 'port' => $port, 'ttl' => $ttl);
-                }
-            }
-        } else {
-            $servers = array(array('server' => '127.0.0.1', 'port' => '6379', 'ttl' => 0.1));
-        }
-
-        // this will have to be revisited to support multiple servers, using
-        // the RedisArray object. That object acts as a proxy object, meaning
-        // most of the class will be the same even after the changes.
-
-        if (count($servers) == 1) {
-            $server = $servers[0];
-            $redis = new \Redis();
-
-            if (isset($server['socket']) && $server['socket']) {
-                $redis->connect($server['socket']);
-            } else {
-                $port = isset($server['port']) ? $server['port'] : 6379;
-                $ttl = isset($server['ttl']) ? $server['ttl'] : 0.1;
-                $redis->connect($server['server'], $port, $ttl);
-            }
-
-            // auth - just password
-            if (isset($options['password'])) {
-                $redis->auth($options['password']);
-            }
-
-            $this->redis = $redis;
-        } else {
-            $redisArrayOptions = array();
-            foreach ($this->redisArrayOptionNames as $optionName) {
-                if (array_key_exists($optionName, $options)) {
-                    $redisArrayOptions[$optionName] = $options[$optionName];
-                }
-            }
-
-            $serverArray = array();
-            foreach ($servers as $server) {
-                $serverString = $server['server'];
-                if (isset($server['port'])) {
-                    $serverString .= ':' . $server['port'];
-                }
-
-                $serverArray[] = $serverString;
-            }
-
-            $redis = new \RedisArray($serverArray, $redisArrayOptions);
-        }
-
-        // select database
-        if (isset($options['database'])) {
-            $redis->select($options['database']);
-        }
-
-        $this->redis = $redis;
-    }
-
-    /**
-     * Properly close the connection.
-     */
-    public function __destruct()
-    {
-        if ($this->redis instanceof \Redis) {
-            try {
-                $this->redis->close();
-            } catch (\RedisException $e) {
-                /*
-                 * \Redis::close will throw a \RedisException("Redis server went away") exception if
-                 * we haven't previously been able to connect to Redis or the connection has severed.
-                 */
-            }
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getData($key)
-    {
-        return unserialize($this->redis->get($this->makeKeyString($key)));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function storeData($key, $data, $expiration)
-    {
-        $store = serialize(array('data' => $data, 'expiration' => $expiration));
-        if (is_null($expiration)) {
-            return $this->redis->set($this->makeKeyString($key), $store);
-        } else {
-            $ttl = $expiration - time();
-
-            // Prevent us from even passing a negative ttl'd item to redis,
-            // since it will just round up to zero and cache forever.
-            if ($ttl < 1) {
-                return true;
-            }
-
-            return $this->redis->setex($this->makeKeyString($key), $ttl, $store);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function clear($key = null)
-    {
-        if (is_null($key)) {
-            $this->redis->flushDB();
-
-            return true;
-        }
-        
-        $pathString = $this->makeKeyString($key, true);
-        $keyString = $this->makeKeyString($key);
-        $this->redis->incr($pathString); // increment index for children items
-        $this->redis->delete($keyString); // remove direct item.
-        $this->deleteSubKeys($keyString);
-        $this->keyCache[$pathString] = array();
-        
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function purge()
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function isAvailable()
-    {
-        return class_exists('Redis', false);
-    }
-    
-    /**
-     * Turns a key array into a key string. This includes running the indexing functions used to manage the Redis
-     * hierarchical storage.
-     *
-     * @param  array  $key
-     * @param  bool   $path
-     * @return string
-     */
-    protected function makeKeyString($key, $path = false)
-    {
-        $key = Stash\Utilities::normalizeKeys($key);
-        
-        $keyString = '';
-        foreach ($key as $name) {
-            $keyString .= $name;
-            
+	protected static $redisArrayOptionNames = [
+		"previous",
+		"function",
+		"distributor",
+		"index",
+		"autorehash",
+		"pconnect",
+		"retry_interval",
+		"lazy_connect",
+		"connect_timeout",
+	];
+	
+	/**
+	 * The Redis drivers.
+	 *
+	 * @var \Redis|\RedisArray
+	 */
+	protected $redis;
+	
+	/**
+	 * The cache of indexed keys.
+	 *
+	 * @var array
+	 */
+	protected $keyCache = [];
+	
+	/**
+	 * If this is true the keyParts will be normalized using the default Utilities::normalizeKeys($key)
+	 *
+	 * @var bool
+	 */
+	protected $normalizeKeys = true;
+	
+	/**
+	 * Properly close the connection.
+	 */
+	public function __destruct() {
+		if ($this->redis instanceof \Redis) {
+			try {
+				$this->redis->close();
+			}
+			catch (\RedisException $e) {
+				/*
+				 * \Redis::close will throw a \RedisException("Redis server went away") exception if
+				 * we haven't previously been able to connect to Redis or the connection has severed.
+				 */
+			}
+		}
+	}
+	
+	/**
+	 * @inheritdoc
+	 */
+	public function getData($key) {
+		return unserialize($this->redis->get($this->makeKeyString($key)));
+	}
+	
+	/**
+	 * @inheritdoc
+	 */
+	public function storeData($key, $data, $expiration) {
+		$serializedData = serialize(
+			[
+				'data'       => $data,
+				'expiration' => $expiration,
+			]
+		);
+		
+		if ($expiration === null) {
+			return $this->redis->set($this->makeKeyString($key), $serializedData);
+		}
+		
+		$ttl = $expiration - time();
+		
+		// Prevent us from even passing a negative ttl'd item to redis,
+		// since it will just round up to zero and cache forever.
+		if ($ttl < 1) {
+			return true;
+		}
+		
+		return $this->redis->setex($this->makeKeyString($key), $ttl, $serializedData);
+	}
+	
+	/**
+	 * @inheritdoc
+	 */
+	public function clear($key = null) {
+		if ($key === null) {
+			return $this->redis->flushDB();
+		}
+		
+		$keyString = $this->makeKeyString($key);
+		$this->redis->delete($keyString); // remove direct item.
+		
+		/**
+		 * If the key has subkeys that means that we will have to remove them too.
+		 * But first we create a new index for the stackparent in the pathdb so we are sure there will be no new
+		 * subkeys added while we are deleting them.
+		 */
+		if ($this->hasSubKeys($keyString)) {
+			$pathString                  = $this->makeKeyString($key, true);
+			$this->keyCache[$pathString] = $this->redis->incr($pathString); //Create a new index and save it in the key cache
+			
+			$this->deleteSubKeys($keyString); // remove all the subitems
+		}
+		
+		return true;
+	}
+	
+	/**
+	 * @inheritdoc
+	 */
+	public function purge() {
+		return true;
+	}
+	
+	/**
+	 * @inheritdoc
+	 */
+	public static function isAvailable() {
+		return class_exists('Redis', false);
+	}
+	
+	/**
+	 * @inheritdoc
+	 */
+	public function isPersistent() {
+		return true;
+	}
+	
+	/**
+	 * The options array should contain an array of servers,
+	 *
+	 * The "server" option expects an array of servers, with each server being represented by an associative array. Each
+	 * redis config must have either a "socket" or a "server" value, and optional "port" and "ttl" values (with the ttl
+	 * representing server timeout, not cache expiration).
+	 *
+	 * The "database" option lets developers specific which specific database to use.
+	 *
+	 * The "password" option is used for clusters which required authentication.
+	 *
+	 * @param array $options
+	 */
+	protected function setOptions(array $options = []) {
+		$options += $this->getDefaultOptions();
+		
+		if (isset($options['normalize_keys'])) {
+			$this->normalizeKeys = $options['normalize_keys'];
+		}
+		
+		// Normalize Server Options
+		if (isset($options['servers']) && count($options['servers']) > 0) {
+			$unprocessedServers = (is_array($options['servers'][0])) ? $options['servers'] : [$options['servers']];
+			$servers            = $this->processServerConfigurations($unprocessedServers);
+		}
+		else {
+			$servers = [['server' => self::SERVER_DEFAULT_HOST, 'port' => self::SERVER_DEFAULT_PORT, 'ttl' => self::SERVER_DEFAULT_TTL]];
+		}
+		
+		/*
+		 * This will have to be revisited to support multiple servers, using the RedisArray object.
+		 * That object acts as a proxy object, meaning most of the class will be the same even after the changes.
+		 */
+		if (count($servers) == 1) {
+			$this->redis = $this->connectToSingleRedisServer($options, $servers[0]);
+		}
+		else {
+			$this->redis = $this->connectToMultipleRedisServers($options, $servers);
+		}
+		
+		// select database
+		if (isset($options['database'])) {
+			$this->redis->select($options['database']);
+		}
+	}
+	
+	/**
+	 * Turns a key array into a key string. This includes running the indexing functions used to manage the Redis
+	 * hierarchical storage.
+	 *
+	 * @param  array $keyParts
+	 * @param  bool  $path
+	 * @return string
+	 * @throws \Exception
+	 */
+	protected function makeKeyString($keyParts, $path = false) {
+		if ($this->normalizeKeys) {
+			$keyParts = Utilities::normalizeKeys($keyParts);
+		}
+		
+		$keyString = '';
+		foreach ($keyParts as $keyPart) {
+			if (!$this->normalizeKeys && (strpos($keyPart, ':') || strpos($keyPart, '_'))) {
+				throw new InvalidArgumentException('You cannot use `:` or `_` in keys if key_normalization is off.');
+			}
+			
+			$keyString .= $keyPart;
+			
 			/*
 			 * Check if there is an index available in the pathdb, that means there was a deletion of the stackparent before
 			 * and we should use the index inside the pathdb to as a prefix for the sub-keys.
+			 *
+			 * However if we are generating the path this should not be included since the index will never get higher than 1 then.
 			 */
-			$pathString = self::$pathPrefix.$keyString;
-			if (isset($this->keyCache[$pathString])) {
-            	$index = $this->keyCache[$pathString];
-			} else {
-				$index = $this->redis->get(self::$pathPrefix.$keyString);
+			if (!$path) {
+				$pathString = self::$pathPrefix.$keyString;
+				if (isset($this->keyCache[$pathString])) {
+					$index = $this->keyCache[$pathString];
+				}
+				else {
+					$index = $this->redis->get($pathString);
+				}
+				
+				if ($index) {
+					$keyString .= '_'.$index;
+				}
 			}
-            
-            if ($index) {
-                $keyString .= '_'.$index;
-            }
-            
-            $keyString .= ':';
-        }
-	
+			
+			$keyString .= ':';
+		}
+		
 		$keyString = rtrim($keyString, ':');
-	
+		
 		return $path ? self::$pathPrefix.$keyString : $keyString;
-    }
-    
-    /**
-     * @param string $keyString
-     */
-    private function deleteSubKeys($keyString) {
-        $iterator = null;
-        
-        while($subKeys = $this->redis->scan($iterator, $keyString.'*')) {
-            foreach ($subKeys as $subKey) {
-                $this->redis->delete($subKey);
-            }
-        }
-    }
-    
-    /**
-     * {@inheritdoc}
-     */
-    public function isPersistent()
-    {
-        return true;
-    }
+	}
+	
+	/**
+	 * @param $keyString
+	 * @return bool
+	 */
+	protected function hasSubKeys($keyString) {
+		/**
+		 * PHPRedis examples are lying. It will not return a boolean false if there are no keys but it will return an empty array.
+		 * But it will also return an empty array if there are no keys fetched in this iteration even though there are more keys to be fetched
+		 * because there are no guarantees given for that.
+		 * So we will need to check whether there are no keys until the iterator is set to 0 which means the whole space has been traversed.
+		 *
+		 * For more information see @link https://redis.io/commands/scan#number-of-elements-returned-at-every-scan-call
+		 */
+		
+		$iterator   = null;
+		$hasSubKeys = false;
+		while ($iterator !== 0 && $hasSubKeys === false) {
+			$hasSubKeys = $this->redis->scan($iterator, $keyString.':*') !== [];
+		}
+		
+		return $hasSubKeys;
+	}
+	
+	/**
+	 * @param string $keyString
+	 */
+	protected function deleteSubKeys($keyString) {
+		//Make sure the pattern matches with in the separator as the last char or else it will also delete the newly indexed keys
+		$pattern = $keyString.':*';
+		
+		$iterator = null;
+		while ($iterator !== 0) {
+			$subKeys = $this->redis->scan($iterator, $pattern);
+			foreach ($subKeys as $subKey) {
+				$this->redis->delete($subKey);
+			}
+		}
+	}
+	
+	/**
+	 * @param array $unprocessedServers
+	 * @return array
+	 */
+	protected function processServerConfigurations(array $unprocessedServers) {
+		$servers = [];
+		foreach ($unprocessedServers as $server) {
+			$ttl = '.1';
+			if (isset($server['ttl'])) {
+				$ttl = $server['ttl'];
+			}
+			elseif (isset($server[2])) {
+				$ttl = $server[2];
+			}
+			
+			if (isset($server['socket'])) {
+				$servers[] = ['socket' => $server['socket'], 'ttl' => $ttl];
+				continue;
+			}
+			
+			$host = self::SERVER_DEFAULT_HOST;
+			if (isset($server['server'])) {
+				$host = $server['server'];
+			}
+			elseif (isset($server[0])) {
+				$host = $server[0];
+			}
+			
+			$port = self::SERVER_DEFAULT_PORT;
+			if (isset($server['port'])) {
+				$port = $server['port'];
+			}
+			elseif (isset($server[1])) {
+				$port = $server[1];
+			}
+			
+			$servers[] = ['server' => $host, 'port' => $port, 'ttl' => $ttl];
+		}
+		
+		return $servers;
+	}
+	
+	/**
+	 * @param array $options
+	 * @param       $server
+	 * @return \Redis
+	 */
+	protected function connectToSingleRedisServer(array $options, $server) {
+		$redis = new \Redis();
+		
+		if (isset($server['socket']) && $server['socket']) {
+			$redis->connect($server['socket']);
+		}
+		else {
+			$redis->connect($server['server'], $server['port'], $server['ttl']);
+		}
+		
+		// auth - just password
+		if (isset($options['password'])) {
+			$redis->auth($options['password']);
+		}
+		
+		return $redis;
+	}
+	
+	/**
+	 * @param array $options
+	 * @param array $servers
+	 * @return \RedisArray
+	 */
+	protected function connectToMultipleRedisServers(array $options, array $servers) {
+		$redisArrayOptions = [];
+		foreach (static::$redisArrayOptionNames as $optionName) {
+			if (isset($options[$optionName])) {
+				$redisArrayOptions[$optionName] = $options[$optionName];
+			}
+		}
+		
+		$serverArray = [];
+		foreach ($servers as $server) {
+			$serverString = $server['server'];
+			if (isset($server['port'])) {
+				$serverString .= ':'.$server['port'];
+			}
+			
+			$serverArray[] = $serverString;
+		}
+		
+		return new \RedisArray($serverArray, $redisArrayOptions);
+	}
 }

--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -27,7 +27,7 @@ class Redis extends AbstractDriver
 {
     const SERVER_DEFAULT_HOST = '127.0.0.1';
     const SERVER_DEFAULT_PORT = 6379;
-    const SERVER_DEFAULT_TTL = 0.1;
+    const SERVER_DEFAULT_TTL  = 0.1;
 
     protected static $pathPrefix = 'pathdb:';
 

--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -259,7 +259,7 @@ class Redis extends AbstractDriver
             
 			/*
 			 * Check if there is an index available in the pathdb, that means there was a deletion of the stackparent before
-			 * and we should use the index inside the pathdb to create the keystring.
+			 * and we should use the index inside the pathdb to as a prefix for the sub-keys.
 			 */
 			$pathString = self::$pathPrefix.$keyString;
 			if (isset($this->keyCache[$pathString])) {

--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -23,366 +23,379 @@ use Stash\Utilities;
  * @author  Robert Hafner <tedivm@tedivm.com>
  * @author  Tim Strijdhorst <tim@decorrespondent.nl>
  */
-class Redis extends AbstractDriver {
-	const SERVER_DEFAULT_HOST = '127.0.0.1';
-	const SERVER_DEFAULT_PORT = 6379;
-	const SERVER_DEFAULT_TTL  = 0.1;
-	
-	protected static $pathPrefix = 'pathdb:';
-	
-	protected static $redisArrayOptionNames = [
-		"previous",
-		"function",
-		"distributor",
-		"index",
-		"autorehash",
-		"pconnect",
-		"retry_interval",
-		"lazy_connect",
-		"connect_timeout",
-	];
-	
-	/**
-	 * The Redis drivers.
-	 *
-	 * @var \Redis|\RedisArray
-	 */
-	protected $redis;
-	
-	/**
-	 * The cache of indexed keys.
-	 *
-	 * @var array
-	 */
-	protected $keyCache = [];
-	
-	/**
-	 * If this is true the keyParts will be normalized using the default Utilities::normalizeKeys($key)
-	 *
-	 * @var bool
-	 */
-	protected $normalizeKeys = true;
-	
-	/**
-	 * Properly close the connection.
-	 */
-	public function __destruct() {
-		if ($this->redis instanceof \Redis) {
-			try {
-				$this->redis->close();
-			}
-			catch (\RedisException $e) {
-				/*
-				 * \Redis::close will throw a \RedisException("Redis server went away") exception if
-				 * we haven't previously been able to connect to Redis or the connection has severed.
-				 */
-			}
-		}
-	}
-	
-	/**
-	 * @inheritdoc
-	 */
-	public function getData($key) {
-		return unserialize($this->redis->get($this->makeKeyString($key)));
-	}
-	
-	/**
-	 * @inheritdoc
-	 */
-	public function storeData($key, $data, $expiration) {
-		$serializedData = serialize(
-			[
-				'data'       => $data,
-				'expiration' => $expiration,
-			]
-		);
-		
-		if ($expiration === null) {
-			return $this->redis->set($this->makeKeyString($key), $serializedData);
-		}
-		
-		$ttl = $expiration - time();
-		
-		// Prevent us from even passing a negative ttl'd item to redis,
-		// since it will just round up to zero and cache forever.
-		if ($ttl < 1) {
-			return true;
-		}
-		
-		return $this->redis->setex($this->makeKeyString($key), $ttl, $serializedData);
-	}
-	
-	/**
-	 * @inheritdoc
-	 */
-	public function clear($key = null) {
-		if ($key === null) {
-			return $this->redis->flushDB();
-		}
-		
-		$keyString = $this->makeKeyString($key);
-		$this->redis->delete($keyString); // remove direct item.
-		
-		/**
-		 * If the key has subkeys that means that we will have to remove them too.
-		 * But first we create a new index for the stackparent in the pathdb so we are sure there will be no new
-		 * subkeys added while we are deleting them.
-		 */
-		if ($this->hasSubKeys($keyString)) {
-			$pathString                  = $this->makeKeyString($key, true);
-			$this->keyCache[$pathString] = $this->redis->incr($pathString); //Create a new index and save it in the key cache
-			
-			$this->deleteSubKeys($keyString); // remove all the subitems
-		}
-		
-		return true;
-	}
-	
-	/**
-	 * @inheritdoc
-	 */
-	public function purge() {
-		return true;
-	}
-	
-	/**
-	 * @inheritdoc
-	 */
-	public static function isAvailable() {
-		return class_exists('Redis', false);
-	}
-	
-	/**
-	 * @inheritdoc
-	 */
-	public function isPersistent() {
-		return true;
-	}
-	
-	/**
-	 * The options array should contain an array of servers,
-	 *
-	 * The "server" option expects an array of servers, with each server being represented by an associative array. Each
-	 * redis config must have either a "socket" or a "server" value, and optional "port" and "ttl" values (with the ttl
-	 * representing server timeout, not cache expiration).
-	 *
-	 * The "database" option lets developers specific which specific database to use.
-	 *
-	 * The "password" option is used for clusters which required authentication.
-	 *
-	 * @param array $options
-	 */
-	protected function setOptions(array $options = []) {
-		$options += $this->getDefaultOptions();
-		
-		if (isset($options['normalize_keys'])) {
-			$this->normalizeKeys = $options['normalize_keys'];
-		}
-		
-		// Normalize Server Options
-		if (isset($options['servers']) && count($options['servers']) > 0) {
-			$unprocessedServers = (is_array($options['servers'][0])) ? $options['servers'] : [$options['servers']];
-			$servers            = $this->processServerConfigurations($unprocessedServers);
-		}
-		else {
-			$servers = [['server' => self::SERVER_DEFAULT_HOST, 'port' => self::SERVER_DEFAULT_PORT, 'ttl' => self::SERVER_DEFAULT_TTL]];
-		}
-		
-		/*
-		 * This will have to be revisited to support multiple servers, using the RedisArray object.
-		 * That object acts as a proxy object, meaning most of the class will be the same even after the changes.
-		 */
-		if (count($servers) == 1) {
-			$this->redis = $this->connectToSingleRedisServer($options, $servers[0]);
-		}
-		else {
-			$this->redis = $this->connectToMultipleRedisServers($options, $servers);
-		}
-		
-		// select database
-		if (isset($options['database'])) {
-			$this->redis->select($options['database']);
-		}
-	}
-	
-	/**
-	 * Turns a key array into a key string. This includes running the indexing functions used to manage the Redis
-	 * hierarchical storage.
-	 *
-	 * @param  array $keyParts
-	 * @param  bool  $path
-	 * @return string
-	 * @throws \Exception
-	 */
-	protected function makeKeyString($keyParts, $path = false) {
-		if ($this->normalizeKeys) {
-			$keyParts = Utilities::normalizeKeys($keyParts);
-		}
-		
-		$keyString = '';
-		foreach ($keyParts as $keyPart) {
-			if (!$this->normalizeKeys && (strpos($keyPart, ':') || strpos($keyPart, '_'))) {
-				throw new InvalidArgumentException('You cannot use `:` or `_` in keys if key_normalization is off.');
-			}
-			
-			$keyString .= $keyPart;
-			
-			/*
-			 * Check if there is an index available in the pathdb, that means there was a deletion of the stackparent before
-			 * and we should use the index inside the pathdb to as a prefix for the sub-keys.
-			 *
-			 * However if we are generating the path this should not be included since the index will never get higher than 1 then.
-			 */
-			if (!$path) {
-				$pathString = self::$pathPrefix.$keyString;
-				if (isset($this->keyCache[$pathString])) {
-					$index = $this->keyCache[$pathString];
-				}
-				else {
-					$index = $this->redis->get($pathString);
-				}
-				
-				if ($index) {
-					$keyString .= '_'.$index;
-				}
-			}
-			
-			$keyString .= ':';
-		}
-		
-		$keyString = rtrim($keyString, ':');
-		
-		return $path ? self::$pathPrefix.$keyString : $keyString;
-	}
-	
-	/**
-	 * @param $keyString
-	 * @return bool
-	 */
-	protected function hasSubKeys($keyString) {
-		/**
-		 * PHPRedis examples are lying. It will not return a boolean false if there are no keys but it will return an empty array.
-		 * But it will also return an empty array if there are no keys fetched in this iteration even though there are more keys to be fetched
-		 * because there are no guarantees given for that.
-		 * So we will need to check whether there are no keys until the iterator is set to 0 which means the whole space has been traversed.
-		 *
-		 * For more information see @link https://redis.io/commands/scan#number-of-elements-returned-at-every-scan-call
-		 */
-		
-		$iterator   = null;
-		$hasSubKeys = false;
-		while ($iterator !== 0 && $hasSubKeys === false) {
-			$hasSubKeys = $this->redis->scan($iterator, $keyString.':*') !== [];
-		}
-		
-		return $hasSubKeys;
-	}
-	
-	/**
-	 * @param string $keyString
-	 */
-	protected function deleteSubKeys($keyString) {
-		//Make sure the pattern matches with in the separator as the last char or else it will also delete the newly indexed keys
-		$pattern = $keyString.':*';
-		
-		$iterator = null;
-		while ($iterator !== 0) {
-			$subKeys = $this->redis->scan($iterator, $pattern);
-			foreach ($subKeys as $subKey) {
-				$this->redis->delete($subKey);
-			}
-		}
-	}
-	
-	/**
-	 * @param array $unprocessedServers
-	 * @return array
-	 */
-	protected function processServerConfigurations(array $unprocessedServers) {
-		$servers = [];
-		foreach ($unprocessedServers as $server) {
-			$ttl = '.1';
-			if (isset($server['ttl'])) {
-				$ttl = $server['ttl'];
-			}
-			elseif (isset($server[2])) {
-				$ttl = $server[2];
-			}
-			
-			if (isset($server['socket'])) {
-				$servers[] = ['socket' => $server['socket'], 'ttl' => $ttl];
-				continue;
-			}
-			
-			$host = self::SERVER_DEFAULT_HOST;
-			if (isset($server['server'])) {
-				$host = $server['server'];
-			}
-			elseif (isset($server[0])) {
-				$host = $server[0];
-			}
-			
-			$port = self::SERVER_DEFAULT_PORT;
-			if (isset($server['port'])) {
-				$port = $server['port'];
-			}
-			elseif (isset($server[1])) {
-				$port = $server[1];
-			}
-			
-			$servers[] = ['server' => $host, 'port' => $port, 'ttl' => $ttl];
-		}
-		
-		return $servers;
-	}
-	
-	/**
-	 * @param array $options
-	 * @param       $server
-	 * @return \Redis
-	 */
-	protected function connectToSingleRedisServer(array $options, $server) {
-		$redis = new \Redis();
-		
-		if (isset($server['socket']) && $server['socket']) {
-			$redis->connect($server['socket']);
-		}
-		else {
-			$redis->connect($server['server'], $server['port'], $server['ttl']);
-		}
-		
-		// auth - just password
-		if (isset($options['password'])) {
-			$redis->auth($options['password']);
-		}
-		
-		return $redis;
-	}
-	
-	/**
-	 * @param array $options
-	 * @param array $servers
-	 * @return \RedisArray
-	 */
-	protected function connectToMultipleRedisServers(array $options, array $servers) {
-		$redisArrayOptions = [];
-		foreach (static::$redisArrayOptionNames as $optionName) {
-			if (isset($options[$optionName])) {
-				$redisArrayOptions[$optionName] = $options[$optionName];
-			}
-		}
-		
-		$serverArray = [];
-		foreach ($servers as $server) {
-			$serverString = $server['server'];
-			if (isset($server['port'])) {
-				$serverString .= ':'.$server['port'];
-			}
-			
-			$serverArray[] = $serverString;
-		}
-		
-		return new \RedisArray($serverArray, $redisArrayOptions);
-	}
+class Redis extends AbstractDriver
+{
+    const SERVER_DEFAULT_HOST = '127.0.0.1';
+    const SERVER_DEFAULT_PORT = 6379;
+    const SERVER_DEFAULT_TTL = 0.1;
+
+    protected static $pathPrefix = 'pathdb:';
+
+    protected static $redisArrayOptionNames = [
+        "previous",
+        "function",
+        "distributor",
+        "index",
+        "autorehash",
+        "pconnect",
+        "retry_interval",
+        "lazy_connect",
+        "connect_timeout",
+    ];
+
+    /**
+     * The Redis drivers.
+     *
+     * @var \Redis|\RedisArray
+     */
+    protected $redis;
+
+    /**
+     * The cache of indexed keys.
+     *
+     * @var array
+     */
+    protected $keyCache = [];
+
+    /**
+     * If this is true the keyParts will be normalized using the default Utilities::normalizeKeys($key)
+     *
+     * @var bool
+     */
+    protected $normalizeKeys = true;
+
+    /**
+     * Properly close the connection.
+     */
+    public function __destruct()
+    {
+        if ($this->redis instanceof \Redis) {
+            try {
+                $this->redis->close();
+            } catch (\RedisException $e) {
+                /*
+                 * \Redis::close will throw a \RedisException("Redis server went away") exception if
+                 * we haven't previously been able to connect to Redis or the connection has severed.
+                 */
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getData($key)
+    {
+        return unserialize($this->redis->get($this->makeKeyString($key)));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function storeData($key, $data, $expiration)
+    {
+        $serializedData = serialize(
+            [
+                'data' => $data,
+                'expiration' => $expiration,
+            ]
+        );
+
+        if ($expiration === null) {
+            return $this->redis->set($this->makeKeyString($key), $serializedData);
+        }
+
+        $ttl = $expiration - time();
+
+        // Prevent us from even passing a negative ttl'd item to redis,
+        // since it will just round up to zero and cache forever.
+        if ($ttl < 1) {
+            return true;
+        }
+
+        return $this->redis->setex($this->makeKeyString($key), $ttl, $serializedData);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function clear($key = null)
+    {
+        if ($key === null) {
+            return $this->redis->flushDB();
+        }
+
+        $keyString = $this->makeKeyString($key);
+        $this->redis->delete($keyString); // remove direct item.
+
+        /**
+         * If the key has subkeys that means that we will have to remove them too.
+         * But first we create a new index for the stackparent in the pathdb so we are sure there will be no new
+         * subkeys added while we are deleting them.
+         */
+        if ($this->hasSubKeys($keyString)) {
+            $pathString = $this->makeKeyString($key, true);
+            $this->keyCache[$pathString] = $this->redis->incr($pathString); //Create a new index and save it in the key cache
+
+            $this->deleteSubKeys($keyString); // remove all the subitems
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function purge()
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function isAvailable()
+    {
+        return class_exists('Redis', false);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isPersistent()
+    {
+        return true;
+    }
+
+    /**
+     * The options array should contain an array of servers,
+     *
+     * The "server" option expects an array of servers, with each server being represented by an associative array. Each
+     * redis config must have either a "socket" or a "server" value, and optional "port" and "ttl" values (with the ttl
+     * representing server timeout, not cache expiration).
+     *
+     * The "database" option lets developers specific which specific database to use.
+     *
+     * The "password" option is used for clusters which required authentication.
+     *
+     * @param array $options
+     */
+    protected function setOptions(array $options = [])
+    {
+        $options += $this->getDefaultOptions();
+
+        if (isset($options['normalize_keys'])) {
+            $this->normalizeKeys = $options['normalize_keys'];
+        }
+
+        // Normalize Server Options
+        if (isset($options['servers']) && count($options['servers']) > 0) {
+            $unprocessedServers = (is_array($options['servers'][0])) ? $options['servers'] : [$options['servers']];
+            $servers = $this->processServerConfigurations($unprocessedServers);
+        } else {
+            $servers = [
+                [
+                    'server' => self::SERVER_DEFAULT_HOST,
+                    'port' => self::SERVER_DEFAULT_PORT,
+                    'ttl' => self::SERVER_DEFAULT_TTL
+                ]
+            ];
+        }
+
+        /*
+         * This will have to be revisited to support multiple servers, using the RedisArray object.
+         * That object acts as a proxy object, meaning most of the class will be the same even after the changes.
+         */
+        if (count($servers) == 1) {
+            $this->redis = $this->connectToSingleRedisServer($options, $servers[0]);
+        } else {
+            $this->redis = $this->connectToMultipleRedisServers($options, $servers);
+        }
+
+        // select database
+        if (isset($options['database'])) {
+            $this->redis->select($options['database']);
+        }
+    }
+
+    /**
+     * Turns a key array into a key string. This includes running the indexing functions used to manage the Redis
+     * hierarchical storage.
+     *
+     * @param  array $keyParts
+     * @param  bool $path
+     * @return string
+     * @throws \Exception
+     */
+    protected function makeKeyString($keyParts, $path = false)
+    {
+        if ($this->normalizeKeys) {
+            $keyParts = Utilities::normalizeKeys($keyParts);
+        }
+
+        $keyString = '';
+        foreach ($keyParts as $keyPart) {
+            if (!$this->normalizeKeys && (strpos($keyPart, ':') || strpos($keyPart, '_'))) {
+                throw new InvalidArgumentException('You cannot use `:` or `_` in keys if key_normalization is off.');
+            }
+
+            $keyString .= $keyPart;
+
+            /*
+             * Check if there is an index available in the pathdb, that means there was a deletion of the stackparent before
+             * and we should use the index inside the pathdb to as a prefix for the sub-keys.
+             *
+             * However if we are generating the path this should not be included since the index will never get higher than 1 then.
+             */
+            if (!$path) {
+                $pathString = self::$pathPrefix . $keyString;
+                if (isset($this->keyCache[$pathString])) {
+                    $index = $this->keyCache[$pathString];
+                } else {
+                    $index = $this->redis->get($pathString);
+                }
+
+                if ($index) {
+                    $keyString .= '_' . $index;
+                }
+            }
+
+            $keyString .= ':';
+        }
+
+        $keyString = rtrim($keyString, ':');
+
+        return $path ? self::$pathPrefix . $keyString : $keyString;
+    }
+
+    /**
+     * @param $keyString
+     * @return bool
+     */
+    protected function hasSubKeys($keyString)
+    {
+        /**
+         * PHPRedis examples are lying. It will not return a boolean false if there are no keys but it will return an empty array.
+         * But it will also return an empty array if there are no keys fetched in this iteration even though there are more keys to be fetched
+         * because there are no guarantees given for that.
+         * So we will need to check whether there are no keys until the iterator is set to 0 which means the whole space has been traversed.
+         *
+         * For more information see @link https://redis.io/commands/scan#number-of-elements-returned-at-every-scan-call
+         */
+
+        $iterator = null;
+        $hasSubKeys = false;
+        while ($iterator !== 0 && $hasSubKeys === false) {
+            $hasSubKeys = $this->redis->scan($iterator, $keyString . ':*') !== [];
+        }
+
+        return $hasSubKeys;
+    }
+
+    /**
+     * @param string $keyString
+     */
+    protected function deleteSubKeys($keyString)
+    {
+        //Make sure the pattern matches with in the separator as the last char or else it will also delete the newly indexed keys
+        $pattern = $keyString . ':*';
+
+        $iterator = null;
+        while ($iterator !== 0) {
+            $subKeys = $this->redis->scan($iterator, $pattern);
+            foreach ($subKeys as $subKey) {
+                $this->redis->delete($subKey);
+            }
+        }
+    }
+
+    /**
+     * @param array $unprocessedServers
+     * @return array
+     */
+    protected function processServerConfigurations(array $unprocessedServers)
+    {
+        $servers = [];
+        foreach ($unprocessedServers as $server) {
+            $ttl = '.1';
+            if (isset($server['ttl'])) {
+                $ttl = $server['ttl'];
+            } elseif (isset($server[2])) {
+                $ttl = $server[2];
+            }
+
+            if (isset($server['socket'])) {
+                $servers[] = ['socket' => $server['socket'], 'ttl' => $ttl];
+                continue;
+            }
+
+            $host = self::SERVER_DEFAULT_HOST;
+            if (isset($server['server'])) {
+                $host = $server['server'];
+            } elseif (isset($server[0])) {
+                $host = $server[0];
+            }
+
+            $port = self::SERVER_DEFAULT_PORT;
+            if (isset($server['port'])) {
+                $port = $server['port'];
+            } elseif (isset($server[1])) {
+                $port = $server[1];
+            }
+
+            $servers[] = ['server' => $host, 'port' => $port, 'ttl' => $ttl];
+        }
+
+        return $servers;
+    }
+
+    /**
+     * @param array $options
+     * @param       $server
+     * @return \Redis
+     */
+    protected function connectToSingleRedisServer(array $options, $server)
+    {
+        $redis = new \Redis();
+
+        if (isset($server['socket']) && $server['socket']) {
+            $redis->connect($server['socket']);
+        } else {
+            $redis->connect($server['server'], $server['port'], $server['ttl']);
+        }
+
+        // auth - just password
+        if (isset($options['password'])) {
+            $redis->auth($options['password']);
+        }
+
+        return $redis;
+    }
+
+    /**
+     * @param array $options
+     * @param array $servers
+     * @return \RedisArray
+     */
+    protected function connectToMultipleRedisServers(array $options, array $servers)
+    {
+        $redisArrayOptions = [];
+        foreach (static::$redisArrayOptionNames as $optionName) {
+            if (isset($options[$optionName])) {
+                $redisArrayOptions[$optionName] = $options[$optionName];
+            }
+        }
+
+        $serverArray = [];
+        foreach ($servers as $server) {
+            $serverString = $server['server'];
+            if (isset($server['port'])) {
+                $serverString .= ':' . $server['port'];
+            }
+
+            $serverArray[] = $serverString;
+        }
+
+        return new \RedisArray($serverArray, $redisArrayOptions);
+    }
 }

--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -22,6 +22,8 @@ use Stash;
  */
 class Redis extends AbstractDriver
 {
+	protected static $pathPrefix = 'pathdb:';
+	
     /**
      * The Redis drivers.
      *
@@ -249,19 +251,21 @@ class Redis extends AbstractDriver
      */
     protected function makeKeyString($key, $path = false)
     {
-    	$pathPrefix = 'pathdb:';
         $key = Stash\Utilities::normalizeKeys($key);
         
         $keyString = '';
         foreach ($key as $name) {
             $keyString .= $name;
             
-            $pathString = $pathPrefix.$keyString;
-            
-            if (isset($this->keyCache[$pathString])) {
+			/*
+			 * Check if there is an index available in the pathdb, that means there was a deletion of the stackparent before
+			 * and we should use the index inside the pathdb to create the keystring.
+			 */
+			$pathString = self::$pathPrefix.$keyString;
+			if (isset($this->keyCache[$pathString])) {
             	$index = $this->keyCache[$pathString];
 			} else {
-				$index = $this->redis->get('pathdb:'.$keyString);
+				$index = $this->redis->get(self::$pathPrefix.$keyString);
 			}
             
             if ($index) {
@@ -273,7 +277,7 @@ class Redis extends AbstractDriver
 	
 		$keyString = rtrim($keyString, ':');
 	
-		return $path ? $pathPrefix.$keyString : $keyString;
+		return $path ? self::$pathPrefix.$keyString : $keyString;
     }
     
     /**

--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -260,8 +260,7 @@ class Redis extends AbstractDriver
             
             if (isset($this->keyCache[$pathString])) {
             	$index = $this->keyCache[$pathString];
-			}
-            else {
+			} else {
 				$index = $this->redis->get('pathdb:'.$keyString);
 			}
             

--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -21,6 +21,7 @@ use Stash\Utilities;
  *
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
+ * @author  Tim Strijdhorst <tim@decorrespondent.nl>
  */
 class Redis extends AbstractDriver {
 	const SERVER_DEFAULT_HOST = '127.0.0.1';

--- a/tests/Stash/Test/Driver/RedisTest.php
+++ b/tests/Stash/Test/Driver/RedisTest.php
@@ -127,7 +127,7 @@ class RedisTest extends AbstractDriverTest
             $expectedException = $e;
         }
 
-        $this->assertInstanceOf(InvalidArgumentException::class, $expectedException);
+        $this->assertInstanceOf('\Stash\Exception\InvalidArgumentException', $expectedException);
         $this->assertEquals('You cannot use `:` or `_` in keys if key_normalization is off.',
             $expectedException->getMessage());
 
@@ -138,7 +138,7 @@ class RedisTest extends AbstractDriverTest
             $expectedException = $e;
         }
 
-        $this->assertInstanceOf(InvalidArgumentException::class, $expectedException);
+        $this->assertInstanceOf('\Stash\Exception\InvalidArgumentException', $expectedException);
         $this->assertEquals('You cannot use `:` or `_` in keys if key_normalization is off.',
             $expectedException->getMessage());
     }

--- a/tests/Stash/Test/Driver/RedisTest.php
+++ b/tests/Stash/Test/Driver/RedisTest.php
@@ -56,7 +56,7 @@ class RedisTest extends AbstractDriverTest
             $this->data['object'] = new \stdClass();
             $this->data['large_string'] = str_repeat('apples', ceil(200000 / 6));
 
-            //Connect a redis client so we can do validation outside of the test we are testing
+            //Connect a redis client so we can do validation outside of the driver we are testing
             $this->redisClient = new \Redis();
             $this->redisClient->connect($this->redisServer, $this->redisPort);
             $this->redisClient->flushDB();
@@ -108,7 +108,7 @@ class RedisTest extends AbstractDriverTest
         $this->deleteSubkeysTest($normalizeKeys = false);
     }
 
-    public function testItDeletedNormalizedSubkeys()
+    public function testItDeletesNormalizedSubkeys()
     {
         $this->deleteSubkeysTest($normalizeKeys = true);
     }

--- a/tests/Stash/Test/Driver/RedisTest.php
+++ b/tests/Stash/Test/Driver/RedisTest.php
@@ -26,13 +26,13 @@ class RedisTest extends AbstractDriverTest
     protected $redisPort = '6379';
 
     protected $redisNoServer = '127.0.0.1';
-    protected $redisNoPort   = 6381;
-    protected $persistence   = true;
-    
+    protected $redisNoPort = 6381;
+    protected $persistence = true;
+
     /** @var  \Redis */
-	protected $redisClient;
-	
-	protected function setUp()
+    protected $redisClient;
+
+    protected function setUp()
     {
         if (!$this->setup) {
             $this->startTime = time();
@@ -46,7 +46,7 @@ class RedisTest extends AbstractDriverTest
             if ($sock = @fsockopen($this->redisNoServer, $this->redisNoPort, $errno, $errstr, 1)) {
                 fclose($sock);
                 $this->markTestSkipped("No server should be listening on {$this->redisNoServer}:{$this->redisNoPort} " .
-                                       "so that we can test for exceptions.");
+                    "so that we can test for exceptions.");
             }
 
             if (!$this->getFreshDriver()) {
@@ -55,36 +55,37 @@ class RedisTest extends AbstractDriverTest
 
             $this->data['object'] = new \stdClass();
             $this->data['large_string'] = str_repeat('apples', ceil(200000 / 6));
-	
+
             //Connect a redis client so we can do validation outside of the test we are testing
-			$this->redisClient = new \Redis();
-			$this->redisClient->connect($this->redisServer, $this->redisPort);
-			$this->redisClient->flushDB();
+            $this->redisClient = new \Redis();
+            $this->redisClient->connect($this->redisServer, $this->redisPort);
+            $this->redisClient->flushDB();
         }
     }
 
     protected function getOptions()
     {
         return [
-        	'servers' => [
-				['server' => $this->redisServer, 'port' => $this->redisPort, 'ttl' => 0.1]
-        	]
-		];
+            'servers' => [
+                ['server' => $this->redisServer, 'port' => $this->redisPort, 'ttl' => 0.1]
+            ]
+        ];
     }
-    
-    protected function getNormalizedOptions($normalizeKeys = true) {
-		$options = $this->getOptions();
-		$options['normalize_keys'] = $normalizeKeys;
-		
-		return $options;
-	}
+
+    protected function getNormalizedOptions($normalizeKeys = true)
+    {
+        $options = $this->getOptions();
+        $options['normalize_keys'] = $normalizeKeys;
+
+        return $options;
+    }
 
     protected function getInvalidOptions()
     {
-		return [
-			'servers' => [
-				['server' => $this->redisNoServer, 'port' => $this->redisNoPort, 'ttl' => 0.1]
-			]
+        return [
+            'servers' => [
+                ['server' => $this->redisNoServer, 'port' => $this->redisNoPort, 'ttl' => 0.1]
+            ]
         ];
     }
 
@@ -101,146 +102,150 @@ class RedisTest extends AbstractDriverTest
         $driver->__destruct();
         $driver = null;
     }
-	
-	public function testItDeletesUnnormalizedSubkeys()
-	{
-		$this->deleteSubkeysTest($normalizeKeys = false);
-	}
-	
-	public function testItDeletedNormalizedSubkeys()
-	{
-		$this->deleteSubkeysTest($normalizeKeys = true);
-	}
-	
-	public function testItCannotUseReservedCharactersIfUnnormalized()
-	{
-		$this->redisClient->flushDB();
-		
-		/** @var Redis $redisDriver */
-		$redisDriver = $this->getFreshDriver($this->getNormalizedOptions($normalizeKeys = false));
-		
-		$expectedException = null;
-		try {
-			$redisDriver->storeData(['cache', 'namespace', 'illegalkey:'], ['data'], null);
-		}
-		catch(InvalidArgumentException $e) {
-			$expectedException = $e;
-		}
-		
-		$this->assertInstanceOf(InvalidArgumentException::class, $expectedException);
-		$this->assertEquals('You cannot use `:` or `_` in keys if key_normalization is off.', $expectedException->getMessage());
-		
-		$expectedException = null;
-		try {
-			$redisDriver->storeData(['cache', 'namespace', 'illegalkey_'], ['data'], null);
-		}
-		catch(InvalidArgumentException $e) {
-			$expectedException = $e;
-		}
-		
-		$this->assertInstanceOf(InvalidArgumentException::class, $expectedException);
-		$this->assertEquals('You cannot use `:` or `_` in keys if key_normalization is off.', $expectedException->getMessage());
-	}
-	
-	public function testItIncreasedTheIndexAfterStackParentDeletion() {
-		$this->redisClient->flushDB();
-  
-		/** @var Redis $redisDriver */
-		$redisDriver = $this->getFreshDriver($this->getNormalizedOptions($normalizeKeys = false));
-		
-		$keyBase = ['cache', 'namespace', 'test', 'directory'];
-		$pathDbProperty = (new \ReflectionClass($redisDriver))->getProperty('pathPrefix');
-		$pathDbProperty->setAccessible(true);
-		$pathDb = $pathDbProperty->getValue($redisDriver);
-		
-		$testKey = $keyBase;
-		$testKey[] = 'key1';
-		$redisDriver->storeData($testKey, ['testData'], null);
-		$this->assertNotFalse($this->redisClient->get('cache:namespace:test:directory:key1'));
-		
-		$redisDriver->clear($keyBase);
-		$this->assertFalse($this->redisClient->get('cache:namespace:test:directory:key1'));
-		$this->assertEquals(1, $this->redisClient->get($pathDb.'cache:namespace:test:directory'));
-		
-		$redisDriver->storeData($testKey,['testData'], null);
-		$this->assertNotFalse($this->redisClient->get('cache:namespace:test:directory_1:key1'));
-		
-		$redisDriver->clear($keyBase);
-		$this->assertFalse($this->redisClient->get('cache:namespace:test:directory_1:key1'));
-		$this->assertEquals(2, $this->redisClient->get($pathDb.'cache:namespace:test:directory'));
-	}
-	
-	public function testItDoesNotIncreaseAnIndexAfterLeafDeletion() {
-		$this->redisClient->flushDB();
-		
-		/** @var Redis $redisDriver */
-		$redisDriver = $this->getFreshDriver($this->getNormalizedOptions($normalizeKeys = false));
-		
-		$keyBase = ['cache', 'namespace', 'test', 'directory'];
-		$pathDbProperty = (new \ReflectionClass($redisDriver))->getProperty('pathPrefix');
-		$pathDbProperty->setAccessible(true);
-		$pathDb = $pathDbProperty->getValue($redisDriver);
-		
-		$redisDriver->storeData($keyBase, ['testData'], null);
-		$this->assertNotFalse($this->redisClient->get('cache:namespace:test:directory'));
-		
-		$redisDriver->clear($keyBase);
-		$this->assertFalse($this->redisClient->get($pathDb.'cache:namespace:test:directory'));
-	}
-	
-	private function deleteSubkeysTest($normalizeKeys = true) {
-    	$this->redisClient->flushDB();
-    	
-    	/** @var Redis $redisDriver */
-		$redisDriver = $this->getFreshDriver($this->getNormalizedOptions($normalizeKeys));
-		
-		$keyBase = ['cache', 'namespace', 'test', 'directory'];
-		
-		$redisDriver->storeData($keyBase, 'stackparent', null);
-		$amountOfTestKeys = 5;
-		//Insert initial data in a stacked structure
-		for ($i = 0; $i < $amountOfTestKeys; $i++) {
-			$key            = $keyBase;
-			$testKeyIndexed = 'test'.$i;
-			$key[]          = $testKeyIndexed;
-			
-			$redisDriver->storeData($key, 'stackChild', null);
-			
-			if ($normalizeKeys) {
-				$key = Utilities::normalizeKeys($key);
-			}
-			$keyCheck = implode(':', $key);
-			
-			$this->assertNotFalse($this->redisClient->get($keyCheck));
-		}
-		
-		//Delete the stackparent
-		$redisDriver->clear($keyBase);
-		
-		$this->assertFalse($redisDriver->getData($keyBase), 'The stackparent should not exist after deletion');
-		
-		//Insert the second batch of data that should now have a new index
-		for ($i = 0; $i < $amountOfTestKeys; $i++) {
-			$key            = $keyBase;
-			$testKeyIndexed = 'test'.$i;
-			$key[]          = $testKeyIndexed;
-			
-			$redisDriver->storeData($key, 'testdata', null);
-			
-			$keyCheckOldIndex = $keyCheckNewIndex = $key;
-			
-			if ($normalizeKeys) {
-				$keyCheckOldIndex = Utilities::normalizeKeys($key);
-				$keyCheckNewIndex = Utilities::normalizeKeys($key);
-			}
-			
-			$keyCheckStringOldIndex = implode(':', $keyCheckOldIndex);
-			
-			$keyCheckNewIndex[count($key) - 2] .= '_1';
-			$keyCheckStringNewIndex            = implode(':', $keyCheckNewIndex);
-			
-			$this->assertFalse($this->redisClient->get($keyCheckStringOldIndex), 'initial keys should be gone');
-			$this->assertNotFalse($this->redisClient->get($keyCheckStringNewIndex), 'second batch of keys should exist with index');
-		}
-	}
+
+    public function testItDeletesUnnormalizedSubkeys()
+    {
+        $this->deleteSubkeysTest($normalizeKeys = false);
+    }
+
+    public function testItDeletedNormalizedSubkeys()
+    {
+        $this->deleteSubkeysTest($normalizeKeys = true);
+    }
+
+    public function testItCannotUseReservedCharactersIfUnnormalized()
+    {
+        $this->redisClient->flushDB();
+
+        /** @var Redis $redisDriver */
+        $redisDriver = $this->getFreshDriver($this->getNormalizedOptions($normalizeKeys = false));
+
+        $expectedException = null;
+        try {
+            $redisDriver->storeData(['cache', 'namespace', 'illegalkey:'], ['data'], null);
+        } catch (InvalidArgumentException $e) {
+            $expectedException = $e;
+        }
+
+        $this->assertInstanceOf(InvalidArgumentException::class, $expectedException);
+        $this->assertEquals('You cannot use `:` or `_` in keys if key_normalization is off.',
+            $expectedException->getMessage());
+
+        $expectedException = null;
+        try {
+            $redisDriver->storeData(['cache', 'namespace', 'illegalkey_'], ['data'], null);
+        } catch (InvalidArgumentException $e) {
+            $expectedException = $e;
+        }
+
+        $this->assertInstanceOf(InvalidArgumentException::class, $expectedException);
+        $this->assertEquals('You cannot use `:` or `_` in keys if key_normalization is off.',
+            $expectedException->getMessage());
+    }
+
+    public function testItIncreasedTheIndexAfterStackParentDeletion()
+    {
+        $this->redisClient->flushDB();
+
+        /** @var Redis $redisDriver */
+        $redisDriver = $this->getFreshDriver($this->getNormalizedOptions($normalizeKeys = false));
+
+        $keyBase = ['cache', 'namespace', 'test', 'directory'];
+        $pathDbProperty = (new \ReflectionClass($redisDriver))->getProperty('pathPrefix');
+        $pathDbProperty->setAccessible(true);
+        $pathDb = $pathDbProperty->getValue($redisDriver);
+
+        $testKey = $keyBase;
+        $testKey[] = 'key1';
+        $redisDriver->storeData($testKey, ['testData'], null);
+        $this->assertNotFalse($this->redisClient->get('cache:namespace:test:directory:key1'));
+
+        $redisDriver->clear($keyBase);
+        $this->assertFalse($this->redisClient->get('cache:namespace:test:directory:key1'));
+        $this->assertEquals(1, $this->redisClient->get($pathDb . 'cache:namespace:test:directory'));
+
+        $redisDriver->storeData($testKey, ['testData'], null);
+        $this->assertNotFalse($this->redisClient->get('cache:namespace:test:directory_1:key1'));
+
+        $redisDriver->clear($keyBase);
+        $this->assertFalse($this->redisClient->get('cache:namespace:test:directory_1:key1'));
+        $this->assertEquals(2, $this->redisClient->get($pathDb . 'cache:namespace:test:directory'));
+    }
+
+    public function testItDoesNotIncreaseAnIndexAfterLeafDeletion()
+    {
+        $this->redisClient->flushDB();
+
+        /** @var Redis $redisDriver */
+        $redisDriver = $this->getFreshDriver($this->getNormalizedOptions($normalizeKeys = false));
+
+        $keyBase = ['cache', 'namespace', 'test', 'directory'];
+        $pathDbProperty = (new \ReflectionClass($redisDriver))->getProperty('pathPrefix');
+        $pathDbProperty->setAccessible(true);
+        $pathDb = $pathDbProperty->getValue($redisDriver);
+
+        $redisDriver->storeData($keyBase, ['testData'], null);
+        $this->assertNotFalse($this->redisClient->get('cache:namespace:test:directory'));
+
+        $redisDriver->clear($keyBase);
+        $this->assertFalse($this->redisClient->get($pathDb . 'cache:namespace:test:directory'));
+    }
+
+    private function deleteSubkeysTest($normalizeKeys = true)
+    {
+        $this->redisClient->flushDB();
+
+        /** @var Redis $redisDriver */
+        $redisDriver = $this->getFreshDriver($this->getNormalizedOptions($normalizeKeys));
+
+        $keyBase = ['cache', 'namespace', 'test', 'directory'];
+
+        $redisDriver->storeData($keyBase, 'stackparent', null);
+        $amountOfTestKeys = 5;
+        //Insert initial data in a stacked structure
+        for ($i = 0; $i < $amountOfTestKeys; $i++) {
+            $key = $keyBase;
+            $testKeyIndexed = 'test' . $i;
+            $key[] = $testKeyIndexed;
+
+            $redisDriver->storeData($key, 'stackChild', null);
+
+            if ($normalizeKeys) {
+                $key = Utilities::normalizeKeys($key);
+            }
+            $keyCheck = implode(':', $key);
+
+            $this->assertNotFalse($this->redisClient->get($keyCheck));
+        }
+
+        //Delete the stackparent
+        $redisDriver->clear($keyBase);
+
+        $this->assertFalse($redisDriver->getData($keyBase), 'The stackparent should not exist after deletion');
+
+        //Insert the second batch of data that should now have a new index
+        for ($i = 0; $i < $amountOfTestKeys; $i++) {
+            $key = $keyBase;
+            $testKeyIndexed = 'test' . $i;
+            $key[] = $testKeyIndexed;
+
+            $redisDriver->storeData($key, 'testdata', null);
+
+            $keyCheckOldIndex = $keyCheckNewIndex = $key;
+
+            if ($normalizeKeys) {
+                $keyCheckOldIndex = Utilities::normalizeKeys($key);
+                $keyCheckNewIndex = Utilities::normalizeKeys($key);
+            }
+
+            $keyCheckStringOldIndex = implode(':', $keyCheckOldIndex);
+
+            $keyCheckNewIndex[count($key) - 2] .= '_1';
+            $keyCheckStringNewIndex = implode(':', $keyCheckNewIndex);
+
+            $this->assertFalse($this->redisClient->get($keyCheckStringOldIndex), 'initial keys should be gone');
+            $this->assertNotFalse($this->redisClient->get($keyCheckStringNewIndex),
+                'second batch of keys should exist with index');
+        }
+    }
 }

--- a/tests/Stash/Test/Driver/RedisTest.php
+++ b/tests/Stash/Test/Driver/RedisTest.php
@@ -11,6 +11,10 @@
 
 namespace Stash\Test\Driver;
 
+use Stash\Driver\Redis;
+use Stash\Exception\InvalidArgumentException;
+use Stash\Utilities;
+
 /**
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
@@ -22,10 +26,13 @@ class RedisTest extends AbstractDriverTest
     protected $redisPort = '6379';
 
     protected $redisNoServer = '127.0.0.1';
-    protected $redisNoPort = '6381';
-    protected $persistence = true;
-
-    protected function setUp()
+    protected $redisNoPort   = 6381;
+    protected $persistence   = true;
+    
+    /** @var  \Redis */
+	protected $redisClient;
+	
+	protected function setUp()
     {
         if (!$this->setup) {
             $this->startTime = time();
@@ -48,21 +55,37 @@ class RedisTest extends AbstractDriverTest
 
             $this->data['object'] = new \stdClass();
             $this->data['large_string'] = str_repeat('apples', ceil(200000 / 6));
+	
+            //Connect a redis client so we can do validation outside of the test we are testing
+			$this->redisClient = new \Redis();
+			$this->redisClient->connect($this->redisServer, $this->redisPort);
+			$this->redisClient->flushDB();
         }
     }
 
     protected function getOptions()
     {
-        return array('servers' => array(
-            array('server' => $this->redisServer, 'port' => $this->redisPort, 'ttl' => 0.1)
-        ));
+        return [
+        	'servers' => [
+				['server' => $this->redisServer, 'port' => $this->redisPort, 'ttl' => 0.1]
+        	]
+		];
     }
+    
+    protected function getNormalizedOptions($normalizeKeys = true) {
+		$options = $this->getOptions();
+		$options['normalize_keys'] = $normalizeKeys;
+		
+		return $options;
+	}
 
     protected function getInvalidOptions()
     {
-        return array('servers' => array(
-            array('server' => $this->redisNoServer, 'port' => $this->redisNoPort, 'ttl' => 0.1)
-        ));
+		return [
+			'servers' => [
+				['server' => $this->redisNoServer, 'port' => $this->redisNoPort, 'ttl' => 0.1]
+			]
+        ];
     }
 
     /**
@@ -78,4 +101,146 @@ class RedisTest extends AbstractDriverTest
         $driver->__destruct();
         $driver = null;
     }
+	
+	public function testItDeletesUnnormalizedSubkeys()
+	{
+		$this->deleteSubkeysTest($normalizeKeys = false);
+	}
+	
+	public function testItDeletedNormalizedSubkeys()
+	{
+		$this->deleteSubkeysTest($normalizeKeys = true);
+	}
+	
+	public function testItCannotUseReservedCharactersIfUnnormalized()
+	{
+		$this->redisClient->flushDB();
+		
+		/** @var Redis $redisDriver */
+		$redisDriver = $this->getFreshDriver($this->getNormalizedOptions($normalizeKeys = false));
+		
+		$expectedException = null;
+		try {
+			$redisDriver->storeData(['cache', 'namespace', 'illegalkey:'], ['data'], null);
+		}
+		catch(InvalidArgumentException $e) {
+			$expectedException = $e;
+		}
+		
+		$this->assertInstanceOf(InvalidArgumentException::class, $expectedException);
+		$this->assertEquals('You cannot use `:` or `_` in keys if key_normalization is off.', $expectedException->getMessage());
+		
+		$expectedException = null;
+		try {
+			$redisDriver->storeData(['cache', 'namespace', 'illegalkey_'], ['data'], null);
+		}
+		catch(InvalidArgumentException $e) {
+			$expectedException = $e;
+		}
+		
+		$this->assertInstanceOf(InvalidArgumentException::class, $expectedException);
+		$this->assertEquals('You cannot use `:` or `_` in keys if key_normalization is off.', $expectedException->getMessage());
+	}
+	
+	public function testItIncreasedTheIndexAfterStackParentDeletion() {
+		$this->redisClient->flushDB();
+  
+		/** @var Redis $redisDriver */
+		$redisDriver = $this->getFreshDriver($this->getNormalizedOptions($normalizeKeys = false));
+		
+		$keyBase = ['cache', 'namespace', 'test', 'directory'];
+		$pathDbProperty = (new \ReflectionClass($redisDriver))->getProperty('pathPrefix');
+		$pathDbProperty->setAccessible(true);
+		$pathDb = $pathDbProperty->getValue($redisDriver);
+		
+		$testKey = $keyBase;
+		$testKey[] = 'key1';
+		$redisDriver->storeData($testKey, ['testData'], null);
+		$this->assertNotFalse($this->redisClient->get('cache:namespace:test:directory:key1'));
+		
+		$redisDriver->clear($keyBase);
+		$this->assertFalse($this->redisClient->get('cache:namespace:test:directory:key1'));
+		$this->assertEquals(1, $this->redisClient->get($pathDb.'cache:namespace:test:directory'));
+		
+		$redisDriver->storeData($testKey,['testData'], null);
+		$this->assertNotFalse($this->redisClient->get('cache:namespace:test:directory_1:key1'));
+		
+		$redisDriver->clear($keyBase);
+		$this->assertFalse($this->redisClient->get('cache:namespace:test:directory_1:key1'));
+		$this->assertEquals(2, $this->redisClient->get($pathDb.'cache:namespace:test:directory'));
+	}
+	
+	public function testItDoesNotIncreaseAnIndexAfterLeafDeletion() {
+		$this->redisClient->flushDB();
+		
+		/** @var Redis $redisDriver */
+		$redisDriver = $this->getFreshDriver($this->getNormalizedOptions($normalizeKeys = false));
+		
+		$keyBase = ['cache', 'namespace', 'test', 'directory'];
+		$pathDbProperty = (new \ReflectionClass($redisDriver))->getProperty('pathPrefix');
+		$pathDbProperty->setAccessible(true);
+		$pathDb = $pathDbProperty->getValue($redisDriver);
+		
+		$redisDriver->storeData($keyBase, ['testData'], null);
+		$this->assertNotFalse($this->redisClient->get('cache:namespace:test:directory'));
+		
+		$redisDriver->clear($keyBase);
+		$this->assertFalse($this->redisClient->get($pathDb.'cache:namespace:test:directory'));
+	}
+	
+	private function deleteSubkeysTest($normalizeKeys = true) {
+    	$this->redisClient->flushDB();
+    	
+    	/** @var Redis $redisDriver */
+		$redisDriver = $this->getFreshDriver($this->getNormalizedOptions($normalizeKeys));
+		
+		$keyBase = ['cache', 'namespace', 'test', 'directory'];
+		
+		$redisDriver->storeData($keyBase, 'stackparent', null);
+		$amountOfTestKeys = 5;
+		//Insert initial data in a stacked structure
+		for ($i = 0; $i < $amountOfTestKeys; $i++) {
+			$key            = $keyBase;
+			$testKeyIndexed = 'test'.$i;
+			$key[]          = $testKeyIndexed;
+			
+			$redisDriver->storeData($key, 'stackChild', null);
+			
+			if ($normalizeKeys) {
+				$key = Utilities::normalizeKeys($key);
+			}
+			$keyCheck = implode(':', $key);
+			
+			$this->assertNotFalse($this->redisClient->get($keyCheck));
+		}
+		
+		//Delete the stackparent
+		$redisDriver->clear($keyBase);
+		
+		$this->assertFalse($redisDriver->getData($keyBase), 'The stackparent should not exist after deletion');
+		
+		//Insert the second batch of data that should now have a new index
+		for ($i = 0; $i < $amountOfTestKeys; $i++) {
+			$key            = $keyBase;
+			$testKeyIndexed = 'test'.$i;
+			$key[]          = $testKeyIndexed;
+			
+			$redisDriver->storeData($key, 'testdata', null);
+			
+			$keyCheckOldIndex = $keyCheckNewIndex = $key;
+			
+			if ($normalizeKeys) {
+				$keyCheckOldIndex = Utilities::normalizeKeys($key);
+				$keyCheckNewIndex = Utilities::normalizeKeys($key);
+			}
+			
+			$keyCheckStringOldIndex = implode(':', $keyCheckOldIndex);
+			
+			$keyCheckNewIndex[count($key) - 2] .= '_1';
+			$keyCheckStringNewIndex            = implode(':', $keyCheckNewIndex);
+			
+			$this->assertFalse($this->redisClient->get($keyCheckStringOldIndex), 'initial keys should be gone');
+			$this->assertNotFalse($this->redisClient->get($keyCheckStringNewIndex), 'second batch of keys should exist with index');
+		}
+	}
 }

--- a/tests/Stash/Test/Driver/RedisTest.php
+++ b/tests/Stash/Test/Driver/RedisTest.php
@@ -22,12 +22,12 @@ use Stash\Utilities;
 class RedisTest extends AbstractDriverTest
 {
     protected $driverClass = 'Stash\Driver\Redis';
-    protected $redisServer = '127.0.0.1';
-    protected $redisPort = '6379';
+    protected $redisServer = '192.168.33.11';
+    protected $redisPort   = 6666;
 
     protected $redisNoServer = '127.0.0.1';
-    protected $redisNoPort = 6381;
-    protected $persistence = true;
+    protected $redisNoPort   = 6381;
+    protected $persistence   = true;
 
     /** @var  \Redis */
     protected $redisClient;

--- a/tests/Stash/Test/Driver/RedisTest.php
+++ b/tests/Stash/Test/Driver/RedisTest.php
@@ -22,8 +22,8 @@ use Stash\Utilities;
 class RedisTest extends AbstractDriverTest
 {
     protected $driverClass = 'Stash\Driver\Redis';
-    protected $redisServer = '192.168.33.11';
-    protected $redisPort   = 6666;
+    protected $redisServer = '127.0.0.1';
+    protected $redisPort   = 6379;
 
     protected $redisNoServer = '127.0.0.1';
     protected $redisNoPort   = 6381;


### PR DESCRIPTION
# Why?

While I was developing with the Redis driver I noticed that if I had a key in the following stackgrouping:

```/directory/test/key1```

And I deleted the stackparent:

```/directory/test/```

Then the original key would not be removed but there was another key added with a number in it. After going through all the code it became apparent that the subkeys are not being actively deleted with the Redis driver (and the newly added key was an index for the stackparent path). This means to me it does not work as advocated, which is a real problem if you have very long TTLs.

# What?

So this PR adds a 'basically atomic in practice' method for subkey deletion. It uses the same index system as is already in place but doesn't normalize all the keys to a single md5 hash so it keeps the structure that is required to be able to delete the subkeys (I'm not sure why you bother to use indexing if you are going to remove it in the final normalization step tbh).

When you delete the stackparent `/directory/test/`, it will create or update the index for that subpath and all subsequent subkeys will be added as `/directory/test_1/` etc. After it has updated the index it will remove all keys that match the old directory prefix. This is what I mean with 'basically atomic' in the sense that as long as the itself process does not fail (i.e connection to Redis has been lost or something similar) it will delete all the old keys.

Redis does support transactions that could make this 'more atomic', until now I haven't really seen a way how this would improve the situation but I am open for the discussion:
https://redis.io/topics/transactions

# Key Normalization

There is also another option specified called 'normalize_keys'. By default it is off not to impose any extra restrictions but unless you have a very very specific reason to use these 2 reserved characters it makes for a much easier to debug key structure.

It will use the standardized key structure for Redis, i.e `/directory/test/key1` becomes `directory:test:key1`.

Documentation:
### ```normalize_keys```
**default value**: true

***Note*** If set to false it is illegal to use ```:``` and ```_``` as part of your keys. Just define them as ```/part/of/a/nice/key/``` without using underscores and you'll be fine.

If set to true all the parts of the keys will be normalized with the default Stash key normalization strategy. In practice this means that all the parts will be converted to md5 hashes. Warning: This may result in pretty long keys, a more intelligent normalization strategy might be required in those cases.

# Tests

Tests are included for all relevant operations.

# Refactor

As you might have noticed I refactored more than strictly necessary. I tried to improve the codestyle where possible while still (hopefully) adhering to the general style of the project.

# Third Party Repo

I also created my own package for just this driver. Mostly because because our company needs this functionality right now.

A secondary reason is because I personally believe that components should inversely depend on eachother and should specify their dependencies clearly. In this case there was nowhere I could find the dependency on phpredis, and it's obvious why you wouldn't include the dependencies in the main composer.json if there are multiple drivers in one project.

The repo can be found at:
https://github.com/Respondens/StashRedisDriver

This is the first time I've made an attempt at such a package so if there is something wrong with the LICENSE or something else please notify me and I'll fix it ASAP.

# Problems encountered

For the separate package I did have a problem with extending the stash tests because the testing namespace for this project is defined in quite a weird way in my opinion. Also while developing this PR I was unable to use the tests except when using the provided runTests.sh. Even though my setup custom setup was using your phpunit.xml.dist and bootstrap.php it would not load the AbstractDriverTest. Therefore I defined my own test structure in my package. It would be nice if we were able to resolve this.

If you do not wish to include this functionality in your codebase I'd ask you to at least notify users that subkeys will not be actively deleted but instead are deleted when their original TTL has diminished and this can potentially fill up their server memory.

I hope you see this as a valuable contribution, if you have any notes or questions do not hesitate to contact me either here or via private channels.