### PR TITLE
[Driver/Composite] Fix PHP 7.2 failure

### DIFF
--- a/src/Stash/Driver/Composite.php
+++ b/src/Stash/Driver/Composite.php
@@ -44,12 +44,16 @@ class Composite extends AbstractDriver
     {
         $options += $this->getDefaultOptions();
 
-        if (!isset($options['drivers']) || (count($options['drivers']) < 1)) {
+        if (!isset($options['drivers'])) {
             throw new RuntimeException('One or more secondary drivers are required.');
         }
 
         if (!is_array($options['drivers'])) {
             throw new InvalidArgumentException('Drivers option requires an array.');
+        }
+
+        if (count($options['drivers']) < 1) {
+            throw new RuntimeException('One or more secondary drivers are required.');
         }
 
         $this->drivers = array();


### PR DESCRIPTION
This pull request fixes a test suite issue when running with upcoming PHP 7.2.

```
$ git clone https://github.com/tedious/Stash.git
Cloning into 'Stash'...
remote: Counting objects: 4811, done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 4811 (delta 2), reused 1 (delta 1), pack-reused 4806
Receiving objects: 100% (4811/4811), 885.59 KiB | 1.34 MiB/s, done.
Resolving deltas: 100% (2797/2797), done.
Checking connectivity... done.


$ cd Stash/


$ git log -1
commit 7ea9749784152dcd2dab72c4bbf2bef18c326e41
Merge: 69313c9 5b7414b
Author: Robert Hafner <tedivm@tedivm.com>
Date:   Sun Apr 23 10:16:57 2017 -0700

    Merge pull request #353 from tedious/hotfix/composer-warnings
    
    Use friendsofphp not fabpot php-cs-fixer


$ composer install
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 35 installs, 0 updates, 0 removals
  - Installing psr/cache (1.0.1): Loading from cache
  - Installing sebastian/diff (1.4.1): Loading from cache
  - Installing symfony/stopwatch (v3.2.7): Loading from cache
  - Installing symfony/process (v3.2.7): Loading from cache
  - Installing symfony/finder (v3.2.7): Loading from cache
  - Installing symfony/filesystem (v3.2.7): Loading from cache
  - Installing symfony/event-dispatcher (v3.2.7): Loading from cache
  - Installing psr/log (1.0.2): Loading from cache
  - Installing symfony/debug (v3.2.7): Loading from cache
  - Installing symfony/polyfill-mbstring (v1.3.0): Loading from cache
  - Installing symfony/console (v3.2.7): Loading from cache
  - Installing friendsofphp/php-cs-fixer (v1.13.1): Loading from cache
  - Installing symfony/yaml (v3.2.7): Loading from cache
  - Installing sebastian/version (1.0.6): Loading from cache
  - Installing sebastian/global-state (1.1.1): Loading from cache
  - Installing sebastian/recursion-context (1.0.5): Loading from cache
  - Installing sebastian/exporter (1.2.2): Loading from cache
  - Installing sebastian/environment (1.3.8): Loading from cache
  - Installing sebastian/comparator (1.2.4): Loading from cache
  - Installing doctrine/instantiator (1.0.5): Loading from cache
  - Installing phpunit/php-text-template (1.2.1): Loading from cache
  - Installing phpunit/phpunit-mock-objects (2.3.8): Loading from cache
  - Installing phpunit/php-timer (1.0.9): Loading from cache
  - Installing phpunit/php-file-iterator (1.4.2): Loading from cache
  - Installing phpunit/php-token-stream (1.4.11): Loading from cache
  - Installing phpunit/php-code-coverage (2.2.4): Loading from cache
  - Installing webmozart/assert (1.2.0): Loading from cache
  - Installing phpdocumentor/reflection-common (1.0): Loading from cache
  - Installing phpdocumentor/type-resolver (0.2.1): Loading from cache
  - Installing phpdocumentor/reflection-docblock (3.1.1): Loading from cache
  - Installing phpspec/prophecy (v1.7.0): Loading from cache
  - Installing phpunit/phpunit (4.8.35): Loading from cache
  - Installing symfony/config (v3.2.7): Loading from cache
  - Installing guzzle/guzzle (v3.8.1): Loading from cache
  - Installing satooshi/php-coveralls (v1.0.1): Loading from cache
symfony/event-dispatcher suggests installing symfony/dependency-injection ()
symfony/event-dispatcher suggests installing symfony/http-kernel ()
sebastian/global-state suggests installing ext-uopz (*)
phpunit/php-code-coverage suggests installing ext-xdebug (>=2.2.1)
phpunit/phpunit suggests installing phpunit/php-invoker (~1.1)
satooshi/php-coveralls suggests installing symfony/http-kernel (Allows Symfony integration)
Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.
Writing lock file
Generating autoload files


$ php72 --version
PHP 7.2.0-dev (cli) (built: Apr 25 2017 08:52:33) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.2.0-dev, Copyright (c) 1998-2017 Zend Technologies


$ php72 vendor/bin/phpunit
PHPUnit 4.8.35 by Sebastian Bergmann and contributors.

.........................SSSSSSS........E......................  63 / 236 ( 26%)
.SS..............SS.......SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS 126 / 236 ( 53%)
SSSSSSSSSSSSSSSSSSS............................................ 189 / 236 ( 80%)
.............................................

Time: 631 ms, Memory: 18.00MB

There was 1 error:

1) Stash\Test\Driver\CompositeTest::testWithBadDriverArgumentException
count(): Parameter must be an array or an object that implements Countable

/tmp/Stash/src/Stash/Driver/Composite.php:47
/tmp/Stash/src/Stash/Driver/AbstractDriver.php:39
/tmp/Stash/tests/Stash/Test/Driver/CompositeTest.php:138

FAILURES!
Tests: 194, Assertions: 2432, Errors: 1, Skipped: 67.
```