### PR TITLE
Apc Driver: Check for 'apc.enable_cli' in cli calls

### DIFF
--- a/src/Stash/Driver/Apc.php
+++ b/src/Stash/Driver/Apc.php
@@ -165,6 +165,10 @@ class Apc extends AbstractDriver
             return false;
         }
 
+	    if (PHP_SAPI === 'cli' && !ini_get('apc.enable_cli')) {
+		    return false;
+	    }
+
         return function_exists('apcu_fetch') || function_exists('apc_fetch');
     }
 

--- a/src/Stash/Driver/Apc.php
+++ b/src/Stash/Driver/Apc.php
@@ -165,9 +165,9 @@ class Apc extends AbstractDriver
             return false;
         }
 
-	    if (PHP_SAPI === 'cli' && (int) ini_get('apc.enable_cli') !== 1) {
-		    return false;
-	    }
+        if (PHP_SAPI === 'cli' && (int) ini_get('apc.enable_cli') !== 1) {
+            return false;
+        }
 
         return function_exists('apcu_fetch') || function_exists('apc_fetch');
     }

--- a/src/Stash/Driver/Apc.php
+++ b/src/Stash/Driver/Apc.php
@@ -165,7 +165,7 @@ class Apc extends AbstractDriver
             return false;
         }
 
-	    if (PHP_SAPI === 'cli' && !ini_get('apc.enable_cli')) {
+	    if (PHP_SAPI === 'cli' && (int) ini_get('apc.enable_cli') !== 1) {
 		    return false;
 	    }
 


### PR DESCRIPTION
As described in #365, Stash can currently run into a fatal error in specific circumstances.

This PR introduces a check in `Apc->isAvailable()` to let the driver fail early if APCu is not configured to run in CLI environments.