### PR TITLE
Add option to limit number of items stored in ephemeral driver.

### DIFF
--- a/tests/Stash/Test/Driver/EphemeralTest.php
+++ b/tests/Stash/Test/Driver/EphemeralTest.php
@@ -59,4 +59,74 @@ class EphemeralTest extends AbstractDriverTest
 
         $this->assertEquals('X', $item1->get());
     }
+
+    /**
+     * @expectedException \Stash\Exception\InvalidArgumentException
+     */
+    public function testSettingMaxItems_InvalidArgument_Throws()
+    {
+        /**
+         * @var \Stash\Driver\Ephemeral
+         */
+        $driver = new $this->driverClass([
+          'maxItems' => null,
+        ]);
+    }
+
+    /**
+     * @expectedException \Stash\Exception\InvalidArgumentException
+     */
+    public function testSettingMaxItems_LessThan0_Throws()
+    {
+        /**
+         * @var \Stash\Driver\Ephemeral
+         */
+        $driver = new $this->driverClass([
+          'maxItems' => -1,
+        ]);
+    }
+
+    public function testEviction()
+    {
+        /**
+         * @var \Stash\Driver\Ephemeral
+         */
+        $driver = new $this->driverClass([
+          'maxItems' => 1,
+        ]);
+
+        $expire = time() + 100;
+        $driver->storeData(['fred'], 'tuttle', $expire);
+        $this->assertArraySubset(
+          ['data' => 'tuttle', 'expiration' => $expire],
+          $driver->getData(['fred'])
+        );
+
+        $driver->storeData(['foo'], 'bar', $expire);
+        $this->assertFalse($driver->getData(['fred']));
+        $this->assertArraySubset(
+          ['data' => 'bar', 'expiration' => $expire],
+          $driver->getData(['foo'])
+        );
+    }
+
+    public function testNoEvictionWithDefaultOptions()
+    {
+        /**
+         * @var \Stash\Driver\Ephemeral
+         */
+        $driver = new $this->driverClass();
+        $expire = time() + 100;
+
+        for ($i = 1; $i <= 5; ++$i) {
+            $driver->storeData(["item$i"], "value$i", $expire);
+        }
+
+        for ($i = 1; $i <= 5; ++$i) {
+            $this->assertArraySubset(
+              ['data' => "value$i", 'expiration' => $expire],
+              $driver->getData(["item$i"])
+            );
+        }
+    }
 }


### PR DESCRIPTION
This makes it possible for the ephemeral driver to use bounded amounts of memory.

It is useful if you want to "cache the cache" in an Ephemeral/Other composite stack, but limit memory consumption, or if you want to use the Ephemeral driver directly in scenarios where the number of unique Items is occasionally very large.