### PR TITLE
speed up purging by optimizing the extraction of expiry timestamps

### DIFF
--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -369,9 +369,9 @@ class FileSystem extends AbstractDriver
                 continue;
             }
 
-            $data = $this->getEncoder()->deserialize($filename);
+            $expiration = $this->getEncoder()->getExpiration($filename);
 
-            if (is_numeric($data['expiration']) && $data['expiration'] <= $startTime) {
+            if (is_numeric($expiration) && $expiration <= $startTime) {
                 unlink($filename);
             }
         }

--- a/src/Stash/Driver/FileSystem/EncoderInterface.php
+++ b/src/Stash/Driver/FileSystem/EncoderInterface.php
@@ -16,4 +16,5 @@ interface EncoderInterface
     public function deserialize($path);
     public function serialize($key, $data);
     public function getExtension();
+    public function getExpiration($path);
 }

--- a/src/Stash/Driver/FileSystem/NativeEncoder.php
+++ b/src/Stash/Driver/FileSystem/NativeEncoder.php
@@ -105,4 +105,42 @@ class NativeEncoder implements EncoderInterface
 
         return $dataString;
     }
+
+    /**
+     * Efficiently extract the expiration timestamp.
+     *
+     * @param $path
+     * @return bool|int|null
+     */
+    public function getExpiration($path)
+    {
+        if (!file_exists($path)) {
+            return false;
+        }
+
+        $file = fopen($path, 'r');
+        for ($i=0; $i<8; $i++) {
+            $line = fread($file, 1024);
+            if (!$line) break;
+        }
+        if (!empty($line) && substr($line, 0, 14) === '$expiration = ') {
+            $expiration = trim(substr($line, 14));
+            if (!empty($expiration)) {
+                return (int)$expiration;
+            }
+        }
+
+        $expiration = null;
+        include($path);
+
+        if (!isset($loaded)) {
+            return false;
+        }
+
+        if (!isset($data)) {
+            $data = null;
+        }
+
+        return $expiration;
+    }
 }

--- a/src/Stash/Driver/FileSystem/NativeEncoder.php
+++ b/src/Stash/Driver/FileSystem/NativeEncoder.php
@@ -121,7 +121,9 @@ class NativeEncoder implements EncoderInterface
         $file = fopen($path, 'r');
         for ($i=0; $i<8; $i++) {
             $line = fread($file, 1024);
-            if (!$line) break;
+            if (!$line) {
+                break;
+            }
         }
         if (!empty($line) && substr($line, 0, 14) === '$expiration = ') {
             $expiration = trim(substr($line, 14));

--- a/src/Stash/Driver/FileSystem/SerializerEncoder.php
+++ b/src/Stash/Driver/FileSystem/SerializerEncoder.php
@@ -46,9 +46,12 @@ class SerializerEncoder implements EncoderInterface
         return '.pser';
     }
 
-    public function getExpiration($path) {
+    public function getExpiration($path)
+    {
         $data = self::deserialize($path);
-        if (empty($data['expiration'])) return false;
+        if (empty($data['expiration'])) {
+            return false;
+        }
 
         return $data['expiration'];
     }

--- a/src/Stash/Driver/FileSystem/SerializerEncoder.php
+++ b/src/Stash/Driver/FileSystem/SerializerEncoder.php
@@ -45,4 +45,11 @@ class SerializerEncoder implements EncoderInterface
     {
         return '.pser';
     }
+
+    public function getExpiration($path) {
+        $data = self::deserialize($path);
+        if (empty($data['expiration'])) return false;
+
+        return $data['expiration'];
+    }
 }

--- a/tests/Stash/Test/Driver/FileSystemSerializerTest.php
+++ b/tests/Stash/Test/Driver/FileSystemSerializerTest.php
@@ -21,9 +21,10 @@ class FileSystemSerializerTest extends FileSystemTest
 {
     protected $driverClass = 'Stash\Driver\FileSystem';
     protected $extension = '.pser';
+    protected $encoder = 'Serializer';
 
     protected function getOptions($options = array())
     {
-        return array_merge(array('memKeyLimit' => 2, 'encoder' => 'Serializer'), $options);
+        return array_merge(array('memKeyLimit' => 2, 'encoder' => $this->encoder), $options);
     }
 }

--- a/tests/Stash/Test/Driver/FileSystemSerializerTest.php
+++ b/tests/Stash/Test/Driver/FileSystemSerializerTest.php
@@ -22,9 +22,4 @@ class FileSystemSerializerTest extends FileSystemTest
     protected $driverClass = 'Stash\Driver\FileSystem';
     protected $extension = '.pser';
     protected $encoder = 'Serializer';
-
-    protected function getOptions($options = array())
-    {
-        return array_merge(array('memKeyLimit' => 2, 'encoder' => $this->encoder), $options);
-    }
 }

--- a/tests/Stash/Test/Driver/FileSystemTest.php
+++ b/tests/Stash/Test/Driver/FileSystemTest.php
@@ -228,4 +228,25 @@ class FileSystemTest extends AbstractDriverTest
         $this->assertLessThanOrEqual($expiration, $expirationFromFile);
         unlink($path);
     }
+
+    /**
+     * Test if expiration is not readable from a file
+     */
+    public function testGetExpirationFalse()
+    {
+        $path = sys_get_temp_dir().
+            DIRECTORY_SEPARATOR.
+            'stash'.
+            DIRECTORY_SEPARATOR.
+            'cache'.
+            DIRECTORY_SEPARATOR.
+            'test'.
+            $this->extension;
+        touch($path);
+
+        $encoderClass = '\Stash\Driver\FileSystem\\'.$this->encoder.'Encoder';
+        $encoder = new $encoderClass();
+        $this->assertFalse($encoder->getExpiration($path));
+        unlink($path);
+    }
 }

--- a/tests/Stash/Test/Driver/FileSystemTest.php
+++ b/tests/Stash/Test/Driver/FileSystemTest.php
@@ -33,7 +33,7 @@ class FileSystemTest extends AbstractDriverTest
 
     protected function getOptions($options = array())
     {
-        return array_merge(array('memKeyLimit' => 2), $options);
+        return array_merge(array('memKeyLimit' => 2, 'encoder' => $this->encoder), $options);
     }
 
     /**
@@ -191,9 +191,9 @@ class FileSystemTest extends AbstractDriverTest
     }
 
     /**
-     * Test if expiry date is readable from cache file
+     * Test if expiration is readable from cache file
      */
-    public function testGetExpiryDate()
+    public function testGetExpiration()
     {
         $driver = new FileSystem($this->getOptions(array(
             'keyHashFunction' => 'Stash\Test\Driver\strdup',
@@ -226,5 +226,6 @@ class FileSystemTest extends AbstractDriverTest
         $expirationFromFile = $encoder->getExpiration($path);
         $this->assertInternalType('integer', $expirationFromFile);
         $this->assertLessThanOrEqual($expiration, $expirationFromFile);
+        unlink($path);
     }
 }


### PR DESCRIPTION
Also uses less memory when caching rather large chunks of data. Currently, only the default encoder (NativeEncoder) is sped up.