### PR TITLE
isHit() should return true after calling save()

### DIFF
--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -470,7 +470,7 @@ class Item implements ItemInterface
     public function save()
     {
         try {
-            return $this->executeSet($this->data, $this->expiration);
+            return $this->isHit = $this->executeSet($this->data, $this->expiration);
         } catch (Exception $e) {
             $this->logException('Setting value in cache caused exception.', $e);
             $this->disable();

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -123,6 +123,17 @@ abstract class AbstractItemTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($item->set($this->data), 'Item without key returns false for set.');
     }
 
+    public function testSetAfterMiss()
+    {
+        $key = array('path', 'to', 'item');
+        $stash = $this->testConstruct($key);
+        $this->assertFalse($stash->isHit(), 'Newly constructed item is a miss');
+        $value = 'test value';
+        $stash->set($value)->save();
+        $this->assertTrue($stash->isHit(), 'newly persisted items are hits');
+        $this->assertEquals($value, $stash->get(), 'get returns newly set data');
+    }
+
     /**
      * @depends testSet
      */


### PR DESCRIPTION
Resolves issue #358 

Commit 25cebe9 was a BC break to achieve PSR-6 compatibility (see issue #327).  This PR doesn't fully revert all BC breaks (which would mean reintroducing PSR incompatibility) but should fix the main pain-point - i.e. that on a cache miss, after calling $item->set($value)->save(), a subsequent $item->get() should return $value not null.

The only real difference to 0.14.1 behaviour is that now calling isHit() after this sequence will return true rather than false - which is necessary for PSR-6 compliance and unlikely to cause any real-world compatibility issues.

IMO, calling get() after set() should also return the value rather than null, but PSR-6 seems fairly explicit about returning null on !isHit(), and I'm not convinced that isHit() should return true on an item that is not yet save()ed.