### PR TITLE
Ensure Ephemeral driver always works with object clones

### DIFF
--- a/src/Stash/Driver/Ephemeral.php
+++ b/src/Stash/Driver/Ephemeral.php
@@ -82,8 +82,18 @@ class Ephemeral extends AbstractDriver
     public function getData($key)
     {
         $key = $this->getKeyIndex($key);
-
-        return isset($this->store[$key]) ? $this->store[$key] : false;
+        
+        if (isset($this->store[$key])) {
+            if (is_object($this->store[$key])) {
+                $data = clone $this->store[$key];
+            } else {
+                $data = $this->store[$key];
+            }
+        } else {
+            $data = false;
+        }
+        
+        return $data;
     }
 
     /**
@@ -109,6 +119,10 @@ class Ephemeral extends AbstractDriver
     {
         if ($this->maxItems > 0 && count($this->store) >= $this->maxItems) {
             $this->evict((count($this->store) + 1) - $this->maxItems);
+        }
+
+        if (is_object($data)) {
+            $data = clone $data;
         }
 
         $this->store[$this->getKeyIndex($key)] = array('data' => $data, 'expiration' => $expiration);


### PR DESCRIPTION
Fix for https://github.com/tedious/Stash/issues/377

The Ephemeral driver methods `Ephemeral::getData` and `Ephemeral::storeData` use object references if data stored in cache is an object. This means that, e.g.
1. storing object `$foo` in cache
2. doing `$foo->name = "not my name"`
3. and then reading from cache will produce an object with name set to "not my name"

Obviously, the data stored in cache should not be a reference, and should be invariant except when changed through the cache driver itself.

Simple clone if data is an object, as implemented here, should do the trick. This could've been written as a nested ternary, but that would've been ugly/unreadable.