### PR TITLE
Encoding Numeric Strings

### DIFF
--- a/src/Stash/Utilities.php
+++ b/src/Stash/Utilities.php
@@ -34,6 +34,10 @@ class Utilities
                 return 'bool';
             }
 
+            if (is_string($data)) {
+                return 'string';
+            }
+
             if (is_numeric($data)) {
                 if (is_numeric($data) && ($data >= 2147483648 || $data < -2147483648)) {
                     return 'serialize';
@@ -41,8 +45,6 @@ class Utilities
                     return 'numeric';
                 }
             }
-
-            return 'string';
         }
 
         return 'serialize';

--- a/tests/Stash/Test/UtilitiesTest.php
+++ b/tests/Stash/Test/UtilitiesTest.php
@@ -25,6 +25,8 @@ class UtilitiesTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(Utilities::encoding(true), 'bool', 'encoding recognized \'true\' boolean.');
         $this->assertEquals(Utilities::encoding(false), 'bool', 'encoding recognized \'false\' boolean');
 
+        $this->assertEquals(Utilities::encoding('1'), 'string', 'encoding recognized \'1\' string.');
+        $this->assertEquals(Utilities::encoding('1.2'), 'string', 'encoding recognized \'1.2\' string.');
         $this->assertEquals(Utilities::encoding('String of doom!'), 'string', 'encoding recognized string scalar');
 
         $this->assertEquals(Utilities::encoding(234), 'numeric', 'encoding recognized integer scalar');


### PR DESCRIPTION
Fix for encoding numeric values in strings.

Current behaviour is saving the value `"1"` into the `FileSystem` cache will detect it as numeric and actually store the integer `1`. This updates that behaviour to return the original string.