### PR TITLE
fix: Redis::delete() is deprecated

### DIFF
--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -216,7 +216,7 @@ class Redis extends AbstractDriver
         $keyString = $this->makeKeyString($key, true);
         $keyReal = $this->makeKeyString($key);
         $this->redis->incr($keyString); // increment index for children items
-        $this->redis->delete($keyReal); // remove direct item.
+        $this->redis->del($keyReal); // remove direct item.
         $this->keyCache = array();
 
         return true;


### PR DESCRIPTION
'delete' is an alias for 'del' and will be removed in a future release
the current redis installation throws a lot of warnings