### PR TITLE
Implement memory limitation for Ephemeral driver

### DIFF
--- a/src/Stash/Driver/Ephemeral.php
+++ b/src/Stash/Driver/Ephemeral.php
@@ -183,5 +183,4 @@ class Ephemeral extends AbstractDriver
 
         return $default;
     }
-
 }

--- a/src/Stash/Driver/Ephemeral.php
+++ b/src/Stash/Driver/Ephemeral.php
@@ -121,7 +121,10 @@ class Ephemeral extends AbstractDriver
 
         if ($this->memoryLimit > 0) {
             while (count($this->store) && memory_get_usage() > $this->memoryLimit) {
-                array_shift($this->store);
+                $numItemsToKeep = count($this->store) * .25;
+                $this->store = $numItemsToKeep > 10
+                    ? array_slice($this->store, $numItemsToKeep, null, true)
+                    : [];
             }
         }
 

--- a/src/Stash/Driver/Ephemeral.php
+++ b/src/Stash/Driver/Ephemeral.php
@@ -58,8 +58,8 @@ class Ephemeral extends AbstractDriver
     {
         $options += $this->getDefaultOptions();
 
-        $this->maxItems = self::positiveIntegerOption($options, 'maxItems', 0);
-        $this->memoryLimit = self::positiveIntegerOption($options, 'memoryLimit', 0);
+        $this->maxItems = self::positiveIntegerOption($options, 'maxItems');
+        $this->memoryLimit = self::positiveIntegerOption($options, 'memoryLimit');
 
         if ($this->maxItems > 0 && count($this->store) > $this->maxItems) {
             $this->evict(count($this->store) - $this->maxItems);
@@ -168,22 +168,19 @@ class Ephemeral extends AbstractDriver
     /**
      * @param array $options
      * @param string $optionName
-     * @param int $default
-     * @return mixed
+     * @return int
      * @throws Stash\Exception\InvalidArgumentException
      */
-    protected static function positiveIntegerOption(array $options, $optionName, $default)
+    protected static function positiveIntegerOption(array $options, $optionName)
     {
-        if (array_key_exists($optionName, $options)) {
-            $optionValue = $options[$optionName];
-            if (!is_int($optionValue) || $optionValue < 0) {
-                throw new Stash\Exception\InvalidArgumentException(
-                    $optionName . ' must be a positive integer.'
-                );
-            }
-            return $optionValue;
+        $optionValue = $options[$optionName];
+
+        if (!is_int($optionValue) || $optionValue < 0) {
+            throw new Stash\Exception\InvalidArgumentException(
+                $optionName . ' must be a positive integer.'
+            );
         }
 
-        return $default;
+        return $optionValue;
     }
 }

--- a/tests/Stash/Test/Driver/EphemeralTest.php
+++ b/tests/Stash/Test/Driver/EphemeralTest.php
@@ -99,15 +99,15 @@ class EphemeralTest extends AbstractDriverTest
         $expire = time() + 100;
         $driver->storeData(['fred'], 'tuttle', $expire);
         $this->assertArraySubset(
-          ['data' => 'tuttle', 'expiration' => $expire],
-          $driver->getData(['fred'])
+            ['data' => 'tuttle', 'expiration' => $expire],
+            $driver->getData(['fred'])
         );
 
         $driver->storeData(['foo'], 'bar', $expire);
         $this->assertFalse($driver->getData(['fred']));
         $this->assertArraySubset(
-          ['data' => 'bar', 'expiration' => $expire],
-          $driver->getData(['foo'])
+            ['data' => 'bar', 'expiration' => $expire],
+            $driver->getData(['foo'])
         );
     }
 
@@ -125,8 +125,8 @@ class EphemeralTest extends AbstractDriverTest
 
         for ($i = 1; $i <= 5; ++$i) {
             $this->assertArraySubset(
-              ['data' => "value$i", 'expiration' => $expire],
-              $driver->getData(["item$i"])
+                ['data' => "value$i", 'expiration' => $expire],
+                $driver->getData(["item$i"])
             );
         }
     }

--- a/tests/Stash/Test/Driver/EphemeralTest.php
+++ b/tests/Stash/Test/Driver/EphemeralTest.php
@@ -157,6 +157,16 @@ class EphemeralTest extends AbstractDriverTest
         ]);
     }
 
+    /**
+     * @expectedException \Stash\Exception\InvalidArgumentException
+     */
+    public function testSettingInvalidMemoryLimitEvictionFactorThrows()
+    {
+        new $this->driverClass([
+            'memoryLimitEvictionFactor' => 98,
+        ]);
+    }
+
     public function testEvictionCausedByMemoryLimit()
     {
         $expire = time() + 100;

--- a/tests/Stash/Test/ItemLoggerTest.php
+++ b/tests/Stash/Test/ItemLoggerTest.php
@@ -62,7 +62,7 @@ class ItemLoggerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(
             'Stash\Test\Exception\TestException',
-                                $logger->lastContext['exception'],
+            $logger->lastContext['exception'],
             'Logger was passed exception in event context.'
         );
 
@@ -82,7 +82,7 @@ class ItemLoggerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(
             'Stash\Test\Exception\TestException',
-                                $logger->lastContext['exception'],
+            $logger->lastContext['exception'],
             'Logger was passed exception in event context.'
         );
         $this->assertTrue(strlen($logger->lastMessage) > 0, 'Logger message set after "set" exception.');
@@ -101,7 +101,7 @@ class ItemLoggerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(
             'Stash\Test\Exception\TestException',
-                                $logger->lastContext['exception'],
+            $logger->lastContext['exception'],
             'Logger was passed exception in event context.'
         );
         $this->assertTrue(strlen($logger->lastMessage) > 0, 'Logger message set after "clear" exception.');

--- a/tests/Stash/Test/SessionTest.php
+++ b/tests/Stash/Test/SessionTest.php
@@ -41,17 +41,17 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(
             '',
             $session->read('session_id'),
-                          'Empty session returns empty string.'
+            'Empty session returns empty string.'
         );
 
         $this->assertTrue(
             $session->write('session_id', 'session_data'),
-                          'Data was written to the session.'
+            'Data was written to the session.'
         );
         $this->assertSame(
             'session_data',
             $session->read('session_id'),
-                          'Active session returns session data.'
+            'Active session returns session data.'
         );
     }
 
@@ -72,7 +72,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue(
             $DataA != $DataB,
-                          'Sessions with different paths do not share data.'
+            'Sessions with different paths do not share data.'
         );
 
         $pool = $this->getPool();
@@ -90,7 +90,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue(
             $DataA != $DataB,
-                          'Sessions with different names do not share data.'
+            'Sessions with different names do not share data.'
         );
     }
 
@@ -99,7 +99,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $session = $this->getSession();
         $this->assertTrue(
             $session->close(),
-                          'Session was closed'
+            'Session was closed'
         );
     }
 
@@ -112,18 +112,18 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(
             'session_data',
             $session->read('session_id'),
-                          'Active session returns session data.'
+            'Active session returns session data.'
         );
 
         $this->assertTrue(
             $session->destroy('session_id'),
-                          'Data was removed from the session.'
+            'Data was removed from the session.'
         );
 
         $this->assertSame(
             '',
             $session->read('session_id'),
-                          'Destroyed session returns empty string.'
+            'Destroyed session returns empty string.'
         );
     }
 
@@ -142,7 +142,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(
             '',
             $sessionC->read('session_id'),
-                          'Purged session returns empty string.'
+            'Purged session returns empty string.'
         );
     }
 


### PR DESCRIPTION
This way we can limit memory occupied by the cached items in Ephemeral driver.

Option name: `memoryLimit` - keep process memory below this edge by evicting items out of the cache.