### PR TITLE
phpdoc fix (Item::$invalidationMethod)

### DIFF
--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -78,7 +78,7 @@ class Item implements ItemInterface
     /**
      * Invalidation method
      *
-     * @var string
+     * @var int
      */
     protected $invalidationMethod = Invalidation::PRECOMPUTE;
 
@@ -269,7 +269,7 @@ class Item implements ItemInterface
     /**
      * {@inheritdoc}
      *
-     * @param string $invalidation
+     * @param int $invalidation
      * @param mixed  $arg
      * @param mixed  $arg2
      */


### PR DESCRIPTION
ItemInterface has the invalidationMethod property as @param int

Item has the invalidationMethod property as @param string ... which causes static analysis tools like phpstan to complain.

This PR just changes the phpdoc comment in Item.php to match the interface's.
