### PR TITLE
Mitigate T_ENCAPSED_AND_WHITESPACE bug

### DIFF
--- a/src/Stash/Driver/FileSystem/NativeEncoder.php
+++ b/src/Stash/Driver/FileSystem/NativeEncoder.php
@@ -22,7 +22,11 @@ class NativeEncoder implements EncoderInterface
         }
 
         $expiration = null;
-        include($path);
+        try {
+            include($path);
+        } catch (\Error $e) {
+            return false;
+        }
 
         if (!isset($loaded)) {
             return false;

--- a/src/Stash/Driver/FileSystem/NativeEncoder.php
+++ b/src/Stash/Driver/FileSystem/NativeEncoder.php
@@ -90,23 +90,20 @@ class NativeEncoder implements EncoderInterface
     {
         switch (Utilities::encoding($data)) {
             case 'bool':
-                $dataString = (bool) $data ? 'true' : 'false';
-                break;
+                return (bool) $data ? 'true' : 'false';
 
             case 'string':
-                $dataString = sprintf('"%s"', addcslashes($data, "\t\"\$\\"));
-                break;
+                return sprintf('"%s"', addcslashes($data, "\t\"\$\\"));
 
             case 'numeric':
-                $dataString = (string) $data;
-                break;
+                return (string) $data;
 
             default:
-                case 'serialize':
-                    $dataString = 'unserialize(base64_decode(\'' . base64_encode(serialize($data)) . '\'))';
-                    break;
+            case 'serialize':
+                if (!is_object($data)) {
+                    return var_export($data, true);
+                }
+                return 'unserialize(base64_decode(\'' . base64_encode(serialize($data)) . '\'))';
         }
-
-        return $dataString;
     }
 }


### PR DESCRIPTION
We recently ran into some trouble because of the slightly obscure and still unfixed T_ENCAPSED_AND_WHITESPACE bug in PHP. It has to do with string parts looking like variables.

First of all, the `include()` should be protected by a try/catch block. This works in PHP 7 and PHP 5 will just ignore the catch block. 
Second, arrays and resources don’t need `serialize()`, they can be enoded with `var_export()` which returns native PHP code. Obviously, this will decode faster and is not prone to the forementioned bug.