### PR TITLE
Modernize PhpUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,10 @@
     "psr/cache": "~1.0"
   },
   "require-dev": {
+    "php": "^7.2|^8.0",
     "friendsofphp/php-cs-fixer": "^2.8",
-    "phpunit/phpunit": "^6",
-    "satooshi/php-coveralls": "1.0.*"
+    "phpunit/phpunit": "^8.0",
+    "php-coveralls/php-coveralls": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -48,12 +48,12 @@ abstract class AbstractItemTest extends \PHPUnit\Framework\TestCase
 
     protected $itemClass = '\Stash\Item';
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass() : void
     {
         Utilities::deleteRecursive(Utilities::getBaseDirectory());
     }
 
-    protected function setUp()
+    protected function setUp() : void
     {
         if (!$this->setup) {
             $this->startTime = time();

--- a/tests/Stash/Test/Driver/AbstractDriverTest.php
+++ b/tests/Stash/Test/Driver/AbstractDriverTest.php
@@ -46,12 +46,12 @@ abstract class AbstractDriverTest extends \PHPUnit\Framework\TestCase
     protected $setup = false;
     protected $persistence = true;
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass() : void
     {
         Utilities::deleteRecursive(Utilities::getBaseDirectory());
     }
 
-    protected function setUp()
+    protected function setUp() : void
     {
         if (!$this->setup) {
             $this->startTime = time();

--- a/tests/Stash/Test/Driver/BlackHoleTest.php
+++ b/tests/Stash/Test/Driver/BlackHoleTest.php
@@ -23,7 +23,7 @@ class BlackHoleTest extends \PHPUnit\Framework\TestCase
      */
     private $driver = null;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->driver = new BlackHole();
     }

--- a/tests/Stash/Test/Driver/MemcacheAnyTest.php
+++ b/tests/Stash/Test/Driver/MemcacheAnyTest.php
@@ -25,7 +25,7 @@ class MemcacheAnyTest extends \PHPUnit\Framework\TestCase
 
     protected $servers = array('127.0.0.1', '11211');
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $driverClass = $this->driverClass;
 

--- a/tests/Stash/Test/Driver/MemcacheTest.php
+++ b/tests/Stash/Test/Driver/MemcacheTest.php
@@ -32,7 +32,7 @@ class MemcacheTest extends AbstractDriverTest
         return array('extension' => $this->extension, 'servers' => $this->servers);
     }
 
-    protected function setUp()
+    protected function setUp() : void
     {
         if (!$this->setup) {
             $this->startTime = time();

--- a/tests/Stash/Test/Driver/RedisArrayTest.php
+++ b/tests/Stash/Test/Driver/RedisArrayTest.php
@@ -23,7 +23,7 @@ class RedisArrayTest extends RedisTest
     protected $redisSecondPort = '6380';
     protected $persistence = true;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped('RedisArray currently not supported by HHVM.');

--- a/tests/Stash/Test/Driver/RedisSocketTest.php
+++ b/tests/Stash/Test/Driver/RedisSocketTest.php
@@ -17,7 +17,7 @@ namespace Stash\Test\Driver;
  */
 class RedisSocketTest extends RedisTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         if (!$this->setup) {
             if (!($sock = @fsockopen('/tmp/redis.sock', null, $errno, $errstr, 1))) {

--- a/tests/Stash/Test/Driver/RedisTest.php
+++ b/tests/Stash/Test/Driver/RedisTest.php
@@ -25,7 +25,7 @@ class RedisTest extends AbstractDriverTest
     protected $redisNoPort = '6381';
     protected $persistence = true;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         if (!$this->setup) {
             $this->startTime = time();

--- a/tests/Stash/Test/Driver/SqliteAnyTest.php
+++ b/tests/Stash/Test/Driver/SqliteAnyTest.php
@@ -25,7 +25,7 @@ class SqliteAnyTest extends \PHPUnit\Framework\TestCase
 {
     protected $driverClass = 'Stash\Driver\Sqlite';
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $driverClass = $this->driverClass;
 
@@ -48,7 +48,7 @@ class SqliteAnyTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($pool->save($item), 'Able to load and store with unconfigured extension.');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass() : void
     {
         Utilities::deleteRecursive(Utilities::getBaseDirectory());
     }

--- a/tests/Stash/Test/Driver/SqlitePdoSqlite3Test.php
+++ b/tests/Stash/Test/Driver/SqlitePdoSqlite3Test.php
@@ -21,7 +21,7 @@ class SqlitePdoSqlite3Test extends AbstractDriverTest
     protected $subDriverClass = 'Stash\Driver\Sub\SqlitePdo';
     protected $persistence = true;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $driver = '\\' . $this->driverClass;
         $subDriver = '\\' . $this->subDriverClass;

--- a/tests/Stash/Test/SessionTest.php
+++ b/tests/Stash/Test/SessionTest.php
@@ -23,7 +23,7 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     protected $testClass = '\Stash\Session';
     protected $poolClass = '\Stash\Pool';
 
-    protected function setUp()
+    protected function setUp() : void
     {
         if (defined('HHVM_VERSION') && version_compare(HHVM_VERSION, '3.0.0', '<')) {
             $this->markTestSkipped('Sessions not supported on older versions of HHVM.');


### PR DESCRIPTION
Composer won't install anything on a PHP 8 environment due to version contraints coming with PhpUnit 6. This PR is a moderate test upgrade.

- PhpUnit 8.0 requires PHP 7.2+
- Needed to update Test method return types such as `public function setUp : void`

N.B. Running PhpUnit will output deprecation warnings on certain test methods, such as `assertAttributeEquals` and `getObjectAttribute`. Tests should work anyhow (though can't tell for sophistaicated cache techniques like Redis, haven't got them)