### PR TITLE
Changed checkFileSystemPermissions arguments so PHP 8 won't throw Deprecated info

### DIFF
--- a/src/Stash/Utilities.php
+++ b/src/Stash/Utilities.php
@@ -209,7 +209,7 @@ class Utilities
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
      */
-    public static function checkFileSystemPermissions($path = null, $permissions)
+    public static function checkFileSystemPermissions($path, string $permissions)
     {
         if (!isset($path)) {
             throw new RuntimeException('Cache path was not set correctly.');


### PR DESCRIPTION
If we have set opcache.enable = 1 with PHP 8, then information is displayed: "Deprecated: Optional parameter $path declared before required parameter $permissions is implicitly treated as a required parameter in /var/www/html/vendor/tedivm/stash/src/Stash/Utilities.php on line 212", it causes a problem with being able to set via ini_set function session.path:

Warning: ini_set(): Session ini settings cannot be changed after headers have already been sent

The proposed change will not affect the operation of the application and will remove information about Deprecated, which will prevent the appearance of Warning