### PR TITLE
Filesystem Driver: Fix dir split not finishing cleanly

### DIFF
--- a/src/Stash/Driver/FileSystem.php
+++ b/src/Stash/Driver/FileSystem.php
@@ -288,14 +288,15 @@ class FileSystem extends AbstractDriver
                 }
 
                 $sLen = strlen($value);
-                $len = floor($sLen / $this->directorySplit);
-                for ($i = 0; $i < $this->directorySplit; $i++) {
-                    $start = $len * $i;
-                    if ($i == $this->directorySplit) {
-                        $len = $sLen - $start;
-                    }
+                $len = (int)floor($sLen / $this->directorySplit);
+                $splitMinusOne = $this->directorySplit - 1;
+                $start = 0;
+                for ($i = 0; $i < $splitMinusOne; $i++) {
                     $path .= substr($value, $start, $len) . DIRECTORY_SEPARATOR;
+                    $start += $len;
                 }
+
+                $path .= substr($value, $start) . DIRECTORY_SEPARATOR;
             }
 
             $path = rtrim($path, DIRECTORY_SEPARATOR) . $this->getEncoder()->getExtension();

--- a/tests/Stash/Test/Driver/FileSystemTest.php
+++ b/tests/Stash/Test/Driver/FileSystemTest.php
@@ -118,6 +118,44 @@ class FileSystemTest extends AbstractDriverTest
         }
     }
 
+
+    /**
+     * Test if the dir split functionality cleanly finished an uneven split e.g. when requested to split "one" into 2, it should split it in "o" and "ne"
+     */
+    public function testDirSplitFinishesCorrectly()
+    {
+        $paths = array('one', 'two', 'three', 'four');
+        $outputpaths = array('o', 'ne', 't', 'wo', 'th', 'ree', 'fo', 'ur');
+
+        $driver = new FileSystem($this->getOptions(array(
+             'keyHashFunction' => function ($key) {
+                 return $key;
+             },
+             'path' => sys_get_temp_dir().DIRECTORY_SEPARATOR.'stash',
+             'dirSplit' => 2
+        )));
+
+        $rand = str_repeat(uniqid(), 32);
+
+        $item = new Item();
+
+        $poolStub = new PoolGetDriverStub();
+        $poolStub->setDriver($driver);
+        $item->setPool($poolStub);
+        $item->setKey($paths);
+        $item->set($rand)->save();
+
+        $allpaths = array_merge(array('ca', 'che'), $outputpaths);
+        $predicted = sys_get_temp_dir().
+          DIRECTORY_SEPARATOR.
+          'stash'.
+          DIRECTORY_SEPARATOR.
+          implode(DIRECTORY_SEPARATOR, $allpaths).
+          $this->extension;
+
+        $this->assertFileExists($predicted);
+    }
+
     /**
      * Test creation of directories with long paths (Windows issue)
      *


### PR DESCRIPTION
I was using Stash as the cache backend for Doctrine, and, being nosy replaced the key hash function with a transparent function (`fn($data) => $data`) and noticed that the names of the files are not completely finished

![Screenshot showing the path "ca/ch/stash/_defaul"](https://user-images.githubusercontent.com/1922630/153733514-5f0a3059-da09-4890-a16a-ced74ea35465.png)

which was a bit alarming because this can cause unintentional cache conflicts or poisoning*

After digging around I found 

https://github.com/tedious/Stash/blob/1a9c7557f928ffa00168fe607725d6cb4e4763da/src/Stash/Driver/FileSystem.php#L292-L298

the `$i == $this->directorySplit` was supposed to prevent this, however this will always be false, thus I have now replaced it with a bit more robust way of splitting that should prevent this.

and which now works correctly as shown here

![Screenshot showing the path "ca/che/stash/_default"](https://user-images.githubusercontent.com/1922630/153733778-34ec1dc8-4086-4b00-8185-2bafc52dca28.png)

*: So this can actually open to cache poisoning attacks, but since the default uses md5 which has an even amount of bytes this is a non-issue unless people use key hash functions with an uneven length return, but these are scarce so ¯\\\_(ツ)\_/¯, an additional "is the key as stored in the item the same as requested" check might be a nice to have, and could prevent this

PS: I am on PHP 8.1 and can't run the outdated phpunit (ok ran my new check by hotfixing it)