### PR TITLE
Add 'username' auth option to Redis driver

### DIFF
--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -57,7 +57,10 @@ class Redis extends AbstractDriver
      *
      * The "database" option lets developers specific which specific database to use.
      *
-     * The "password" option is used for clusters which required authentication.
+     * The "password" option is used for clusters which require authentication.
+     *
+     * The "username" option is used for authentication with a non-default user, for clusters which have ACL rules.
+     * If "username" isn't set, but "password" is set, the `default` user will be used for authentication.
      *
      * @param array $options
      */
@@ -121,9 +124,18 @@ class Redis extends AbstractDriver
                 $redis->connect($server['server'], $port, $ttl);
             }
 
-            // auth - just password
+            // authentication
             if (isset($options['password'])) {
-                $redis->auth($options['password']);
+                if (isset($options['username'])) {
+                    $redis->auth(
+                        [
+                            'user' => $options['username'],
+                            'pass' => $options['password']
+                        ]
+                    );
+                } else {
+                    $redis->auth(['pass' => $options['password']]);
+                }
             }
 
             $this->redis = $redis;


### PR DESCRIPTION
This PR implements an additional option `username` to be used with Redis clusters that have ACL rules (Redis 6+) with non-default users.

I have changed the `auth` method parameters to use associative arrays, because I thought it would be less confusing to someone reading the code. More info on parameter styles [here](https://github.com/phpredis/phpredis#auth).

How I tested it:

- Start a Redis container without authentication enabled.
  - Try to connect and get something, without setting `username` or `password`.
  - Result: "cache miss" (OK).
  - Try to connect and get something, setting only the `password` option.
  - Result:`Fatal error: Uncaught RedisException: ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct? in /usr/src/src/Stash/Driver/Redis.php:137` (followed by a stack trace).
    - Observation: this is already the default behavior of this library.
  - Try to connect and get something, setting `username` and `password`.
  - Result: `Fatal error: Uncaught RedisException: WRONGPASS invalid username-password pair or user is disabled. in /usr/src/src/Stash/Driver/Redis.php:133` (followed by a stack trace).

- Start a Redis container and change the authentication password for the default user.
  - Use this command: `ACL SETUSER default >somepassword`
  - Try to connect and get something, without setting `username` or `password`.
  - Result: `Caught exception: NOAUTH Authentication required.` (I used a `try-catch` block of code).
  - Try to connect and get something, setting only the `password` option.
  - Result: "cache miss" (OK).
  - Try to connect and get something, setting `username` and `password`.
  - Result: `Fatal error: Uncaught RedisException: WRONGPASS invalid username-password pair or user is disabled. in /usr/src/src/Stash/Driver/Redis.php:133`  (followed by a stack trace).

- Start a Redis container and create a new user, disabling the `default` user.
  - Use the commands:
    -  `ACL SETUSER default off`
    - `ACL SETUSER someuser on allkeys allcommands allchannels >somepasshere`
  - Try to connect and get something, without setting `username` or `password`.
  - Result: `Caught exception: NOAUTH Authentication required.` (I used a `try-catch` block of code).
  - Try to connect and get something, setting only the `password` option.
  - Result: `Fatal error: Uncaught RedisException: ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct? in /usr/src/src/Stash/Driver/Redis.php:137` (followed by a stack trace).
  - Try to connect and get something, setting `username` and `password` options.
  - Result: "cache miss" (OK).


Closes #412

