### PR TITLE
Fix deprecation error on php 8.1

### DIFF
--- a/src/Stash/Driver/Sub/Memcached.php
+++ b/src/Stash/Driver/Sub/Memcached.php
@@ -186,7 +186,7 @@ class Memcached
      */
     public function cas($key, $value)
     {
-        $token = null;
+        $token = 0;
         if (($rValue = $this->memcached->get($key, null, $token)) !== false) {
             return $rValue;
         }


### PR DESCRIPTION
Use 0.17.5 version with php 8.1 and get such error:

```
Deprecated: Memcached::get(): Passing null to parameter #3 ($get_flags) of type int is deprecated in /app/www/vendor/tedivm/stash/src/Stash/Driver/Sub/Memcached.php on line 190
```