### PR TITLE
Fix #416 Session class incompatibility with PHP 7.x/8+

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ["8.0", "8.1", "latest"]
+        php_version: ["7.2", "7.4", "8.0", "8.1", "latest"]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ["7.2", "7.4", "8.0", "8.1", "latest"]
+        php_version: ["7.4", "8.0", "8.1", "latest"]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 env:
   IS_GITHUB: "true"
 


### PR DESCRIPTION
Due to difference in SessionInterfaceHandler interface in PHP 7.x and PHP 8+ gc method return type was ommited and suppressed warning as PHP 8+ It's better for future to make different version of Stash for PHP 7.x and PHP 8+

Minor change was made also to remove cmpatibility with PHP version before 5.4.0 while Stash package is compatible with 7+.