### PR TITLE
Update to psr/cache 3.0

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -33,4 +33,5 @@ jobs:
     - name: Run Tests
       uses: php-actions/phpunit@v3
       with:
+        version: 9.6.16
         php_version: ${{ matrix.php_version }}

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,10 @@
     }
   ],
   "require": {
-    "php": ">7.0",
-    "psr/cache": "~1.0"
+    "php": "^8.0",
+    "psr/cache": "^2|^3"
   },
   "require-dev": {
-    "php": "^7.2|^8.0",
     "friendsofphp/php-cs-fixer": "^2.8",
     "phpunit/phpunit": "^9.0",
     "php-coveralls/php-coveralls": "^2.0",
@@ -41,6 +40,6 @@
     }
   },
   "provide": {
-    "psr/cache-implementation": "1.0.0"
+    "psr/cache-implementation": "2.0|3.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.8",
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^9.0|^10",
     "php-coveralls/php-coveralls": "^2.0",
-    "dms/phpunit-arraysubset-asserts": "^0.4.0"
+    "dms/phpunit-arraysubset-asserts": "^0.5.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Stash/Exception/ItemKeyMissingException.php
+++ b/src/Stash/Exception/ItemKeyMissingException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Stash package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Stash\Exception;
+
+/**
+ * Exception thrown when an item key is missing
+ *
+ * Class ItemKeyMissingException
+ * @package Stash\Exception
+ * @author  Korvin Szanto <me@kor.vin>
+ */
+class ItemKeyMissingException extends \RuntimeException implements Exception
+{
+}

--- a/src/Stash/Interfaces/ItemInterface.php
+++ b/src/Stash/Interfaces/ItemInterface.php
@@ -12,6 +12,7 @@
 namespace Stash\Interfaces;
 
 use \Psr\Cache\CacheItemInterface;
+use Psr\Log\LoggerInterface;
 
 interface ItemInterface extends CacheItemInterface
 {
@@ -22,7 +23,7 @@ interface ItemInterface extends CacheItemInterface
      *
      * @param PoolInterface $driver
      */
-    public function setPool(PoolInterface $driver);
+    public function setPool(PoolInterface $driver): void;
 
     /**
      * Takes and sets the key and namespace.
@@ -32,7 +33,7 @@ interface ItemInterface extends CacheItemInterface
      * @param array       $key
      * @param string|null $namespace
      */
-    public function setKey(array $key, $namespace = null);
+    public function setKey(array $key, string $namespace = null): void;
 
     /**
      * This disables any IO operations by this object, effectively preventing
@@ -40,7 +41,7 @@ interface ItemInterface extends CacheItemInterface
      *
      * @return bool
      */
-    public function disable();
+    public function disable(): bool;
 
     /**
      * Returns the key as a string. This is particularly useful when the Item is
@@ -48,7 +49,7 @@ interface ItemInterface extends CacheItemInterface
      *
      * @return string
      */
-    public function getKey();
+    public function getKey(): string;
 
     /**
      * Clears the current Item. If hierarchical or "stackable" caching is being
@@ -56,7 +57,7 @@ interface ItemInterface extends CacheItemInterface
      *
      * @return bool
      */
-    public function clear();
+    public function clear(): bool;
 
     /**
      * Returns the data retrieved from the cache. Since this can return false or
@@ -67,21 +68,21 @@ interface ItemInterface extends CacheItemInterface
      *
      * @return mixed
      */
-    public function get();
+    public function get(): mixed;
 
     /**
      * Returns true if the cached item is valid and usable.
      *
      * @return bool
      */
-    public function isHit();
+    public function isHit(): bool;
 
     /**
      * Returns true if the cached item needs to be refreshed.
      *
      * @return bool
      */
-    public function isMiss();
+    public function isMiss(): bool;
 
     /**
      * Enables stampede protection by marking this specific instance of the Item
@@ -90,7 +91,7 @@ interface ItemInterface extends CacheItemInterface
      * @param  null $ttl
      * @return bool
      */
-    public function lock($ttl = null);
+    public function lock(int $ttl = null): bool;
 
     /**
      * Takes and stores data for later retrieval. This data can be any php data,
@@ -100,23 +101,23 @@ interface ItemInterface extends CacheItemInterface
      * @param  mixed $value bool
      * @return self
      */
-    public function set($value);
+    public function set(mixed $value): static;
 
     /**
      * Extends the expiration on the current cached item. For some engines this
      * can be faster than storing the item again.
      *
-     * @param  null $ttl
-     * @return bool
+     * @param  int|\DateInterval|null $ttl
+     * @return \Stash\Item|bool
      */
-    public function extend($ttl = null);
+    public function extend(int|\DateInterval $ttl = null): \Stash\Item|bool;
 
     /**
      * Return true if caching is disabled
      *
      * @return bool True if caching is disabled.
      */
-    public function isDisabled();
+    public function isDisabled(): bool;
 
     /**
      * Sets a PSR\Logger style logging client to enable the tracking of errors.
@@ -124,61 +125,61 @@ interface ItemInterface extends CacheItemInterface
      * @param  \PSR\Log\LoggerInterface $logger
      * @return bool
      */
-    public function setLogger($logger);
+    public function setLogger(LoggerInterface $logger): bool;
 
     /**
      * Returns the record's creation time or false if it isn't set
      *
-     * @return \DateTime
+     * @return \DateTime|bool
      */
-    public function getCreation();
+    public function getCreation(): \DateTime|bool;
 
     /**
      * Returns the record's expiration timestamp or false if no expiration timestamp is set
      *
      * @return \DateTime
      */
-    public function getExpiration();
+    public function getExpiration(): \DateTime;
 
     /**
     * Sets the expiration based off of an integer or DateInterval
     *
-    * @param int|\DateInterval $time
+    * @param int|\DateInterval|null $time
     * @return self
     */
-    public function expiresAfter($time);
+    public function expiresAfter(int|\DateInterval|null $time): static;
 
     /**
     * Sets the expiration to a specific time.
     *
-    * @param \DateTimeInterface $expiration
+    * @param \DateTimeInterface|null $expiration
     * @return self
     */
-    public function expiresAt($expiration);
+    public function expiresAt(\DateTimeInterface|null $expiration): static;
 
     /**
     * Sets the expiration based off a an integer, date interval, or date
     *
-    * @param mixed $ttl An integer, date interval, or date
+    * @param int|\DateInterval|\DateTimeInterface|null $ttl An integer, date interval, or date
     * @return self
     */
-    public function setTTL($ttl = null);
+    public function setTTL(int|\DateInterval|\DateTimeInterface $ttl = null): static;
 
     /**
     * Set the cache invalidation method for this item.
     *
-    * @see Stash\Invalidation
+    * @see \Stash\Invalidation
     *
     * @param int   $invalidation A Stash\Invalidation constant
     * @param mixed $arg          First argument for invalidation method
     * @param mixed $arg2         Second argument for invalidation method
     */
-    public function setInvalidationMethod($invalidation, $arg = null, $arg2 = null);
+    public function setInvalidationMethod(int $invalidation, mixed $arg = null, mixed $arg2 = null): void;
 
     /**
     * Persists the Item's value to the backend storage.
     *
     * @return bool
     */
-    public function save();
+    public function save(): bool;
 }

--- a/src/Stash/Interfaces/PoolInterface.php
+++ b/src/Stash/Interfaces/PoolInterface.php
@@ -13,6 +13,8 @@ namespace Stash\Interfaces;
 
 use \Psr\Cache\CacheItemPoolInterface;
 use \Psr\Cache\CacheItemInterface;
+use Psr\Log\LoggerInterface;
+use Stash\Exception\ItemKeyMissingException;
 
 /**
  *
@@ -31,7 +33,7 @@ interface PoolInterface extends CacheItemPoolInterface
      * @return bool
      * @throws \InvalidArgumentException When passed invalid or nonexistant classes.
      */
-    public function setItemClass($class);
+    public function setItemClass(string $class): bool;
 
     /**
      * Returns an initialized Item for a given Key.
@@ -57,8 +59,9 @@ interface PoolInterface extends CacheItemPoolInterface
      * @param  string              $key
      * @return ItemInterface
      * @throws \InvalidArgumentException
+     * @throws ItemKeyMissingException When the item cannot be saved due to missing item key
      */
-    public function getItem($key);
+    public function getItem(string $key): CacheItemInterface;
 
     /**
      * Returns a group of cache objects in an \Iterator
@@ -67,9 +70,9 @@ interface PoolInterface extends CacheItemPoolInterface
      * each key passed, but is not required to maintain an order.
      *
      * @param  array     $keys
-     * @return array|\Traversable
+     * @return iterable
      */
-    public function getItems(array $keys = array());
+    public function getItems(array $keys = []): iterable;
 
     /**
      * Empties the entire cache pool of all Items.
@@ -78,7 +81,7 @@ interface PoolInterface extends CacheItemPoolInterface
      *
      * @return bool True on success
      */
-    public function clear();
+    public function clear(): bool;
 
     /**
      * The Purge function allows drivers to perform basic maintenance tasks, such as removing stale or expired items
@@ -89,7 +92,7 @@ interface PoolInterface extends CacheItemPoolInterface
      *
      * @return bool success
      */
-    public function purge();
+    public function purge(): bool;
 
     /**
      * Sets the driver for use by the caching system. This driver handles the direct interfaceion with the caching
@@ -97,66 +100,66 @@ interface PoolInterface extends CacheItemPoolInterface
      *
      * @param DriverInterface $driver
      */
-    public function setDriver(\Stash\Interfaces\DriverInterface $driver);
+    public function setDriver(DriverInterface $driver): void;
 
     /**
      * Returns the current driver used by the Pool.
      *
      * @return DriverInterface
      */
-    public function getDriver();
+    public function getDriver(): DriverInterface;
 
     /**
      * Places the Pool inside of a "namespace". All Items inside a specific namespace should be completely segmented
      * from all other Items.
      *
-     * @param  string                    $namespace Namespaces must be alphanumeric
+     * @param  string|null               $namespace Namespaces must be alphanumeric
      * @return bool
      * @throws \InvalidArgumentException Namespaces must be alphanumeric
      */
-    public function setNamespace($namespace = null);
+    public function setNamespace(string $namespace = null): bool;
 
     /**
      * Returns the current namespace, or false if no namespace was set.
      *
      * @return string|false
      */
-    public function getNamespace();
+    public function getNamespace(): string|bool;
 
     /**
      * Sets a PSR\Logger style logging client to enable the tracking of errors.
      *
-     * @param  \PSR\Log\LoggerInterface $logger
+     * @param  LoggerInterface $logger
      * @return bool
      */
-    public function setLogger($logger);
+    public function setLogger(LoggerInterface $logger): bool;
 
     /**
      * Sets the default cache invalidation method for items created by this pool object.
      *
-     * @see Stash\Invalidation
+     * @see \Stash\Invalidation
      *
      * @param int   $invalidation A Stash\Invalidation constant
      * @param mixed $arg          First argument for invalidation method
      * @param mixed $arg2         Second argument for invalidation method
      */
-    public function setInvalidationMethod($invalidation, $arg = null, $arg2 = null);
+    public function setInvalidationMethod(int $invalidation, mixed $arg = null, mixed $arg2 = null): bool;
 
     /**
     * Forces any save-deferred objects to get flushed to the backend drivers.
     *
     * @return bool
     */
-    public function commit();
+    public function commit(): bool;
 
     /**
     * Sets an Item to be saved at some point. This allows buffering for
     * multi-save events.
     *
     * @param CacheItemInterface $item
-    * @return static The invoked object.
+    * @return bool.
     */
-    public function saveDeferred(CacheItemInterface $item);
+    public function saveDeferred(CacheItemInterface $item): bool;
 
     /**
     * Sets an Item to be saved immediately.
@@ -164,7 +167,7 @@ interface PoolInterface extends CacheItemPoolInterface
     * @param CacheItemInterface $item
     * @return bool
     */
-    public function save(CacheItemInterface $item);
+    public function save(CacheItemInterface $item): bool;
 
     /**
      * Removes multiple items from the pool by their key.
@@ -172,7 +175,7 @@ interface PoolInterface extends CacheItemPoolInterface
      * @param array $keys
      * @return bool
      */
-    public function deleteItems(array $keys);
+    public function deleteItems(array $keys): bool;
 
     /**
      * Removes single item from the pool by its key.
@@ -180,7 +183,7 @@ interface PoolInterface extends CacheItemPoolInterface
      * @param string $key
      * @return bool
      */
-    public function deleteItem($key);
+    public function deleteItem(string $key): bool;
 
     /**
     * Checks for the existance of an item in the cache.
@@ -188,5 +191,5 @@ interface PoolInterface extends CacheItemPoolInterface
     * @param  string $key
     * @return boolean True if item exists in the cache, false otherwise.
     */
-    public function hasItem($key);
+    public function hasItem(string $key): bool;
 }

--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -12,6 +12,7 @@
 namespace Stash;
 
 use Psr\Cache\CacheItemInterface;
+use Psr\Log\LoggerInterface;
 use Stash\Exception\InvalidArgumentException;
 use Stash\Driver\Ephemeral;
 use Stash\Interfaces\DriverInterface;
@@ -52,7 +53,7 @@ class Pool implements PoolInterface
      * If set various then errors and exceptions will get passed to the PSR Compliant logging library. This
      * can be set using the setLogger() function in this class.
      *
-     * @var Psr\Log\LoggerInterface
+     * @var \Psr\Log\LoggerInterface
      */
     protected $logger;
 
@@ -103,7 +104,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function setItemClass($class)
+    public function setItemClass(string $class): bool
     {
         if (!class_exists($class)) {
             throw new InvalidArgumentException('Item class ' . $class . ' does not exist');
@@ -123,7 +124,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function getItem($key)
+    public function getItem(string $key): CacheItemInterface
     {
         $keyString = trim($key, '/');
         $key = explode('/', $keyString);
@@ -157,7 +158,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function getItems(array $keys = array())
+    public function getItems(array $keys = array()): iterable
     {
         // temporarily cheating here by wrapping around single calls.
 
@@ -173,7 +174,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function hasItem($key)
+    public function hasItem(string $key): bool
     {
         return $this->getItem($key)->isHit();
     }
@@ -181,7 +182,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function save(CacheItemInterface $item)
+    public function save(CacheItemInterface $item): bool
     {
         return $item->save();
     }
@@ -189,7 +190,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function saveDeferred(CacheItemInterface $item)
+    public function saveDeferred(CacheItemInterface $item): bool
     {
         return $this->save($item);
     }
@@ -197,7 +198,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function commit()
+    public function commit(): bool
     {
         return true;
     }
@@ -206,7 +207,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteItems(array $keys)
+    public function deleteItems(array $keys): bool
     {
         // temporarily cheating here by wrapping around single calls.
         $results = true;
@@ -221,7 +222,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteItem($key)
+    public function deleteItem(string $key): bool
     {
         return $this->getItem($key)->clear();
     }
@@ -230,7 +231,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function clear()
+    public function clear(): bool
     {
         if ($this->isDisabled) {
             return false;
@@ -258,7 +259,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function purge()
+    public function purge(): bool
     {
         if ($this->isDisabled) {
             return false;
@@ -279,7 +280,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function setDriver(DriverInterface $driver)
+    public function setDriver(DriverInterface $driver): void
     {
         $this->driver = $driver;
     }
@@ -287,7 +288,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function getDriver()
+    public function getDriver(): DriverInterface
     {
         return $this->driver;
     }
@@ -295,7 +296,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function setNamespace($namespace = null)
+    public function setNamespace(string $namespace = null): bool
     {
         if (is_null($namespace)) {
             $this->namespace = null;
@@ -315,7 +316,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function getNamespace()
+    public function getNamespace(): bool|string
     {
         return isset($this->namespace) ? $this->namespace : false;
     }
@@ -323,7 +324,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function setLogger($logger)
+    public function setLogger(LoggerInterface $logger): bool
     {
         $this->logger = $logger;
 
@@ -333,8 +334,11 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function setInvalidationMethod($invalidation = Invalidation::PRECOMPUTE, $arg = null, $arg2 = null)
-    {
+    public function setInvalidationMethod(
+        int $invalidation = Invalidation::PRECOMPUTE,
+        mixed $arg = null,
+        mixed $arg2 = null
+    ): bool {
         $this->invalidationMethod = $invalidation;
         $this->invalidationArg1 = $arg;
         $this->invalidationArg2 = $arg2;
@@ -349,7 +353,7 @@ class Pool implements PoolInterface
      * @param  \Exception $exception
      * @return bool
      */
-    protected function logException($message, $exception)
+    protected function logException(string $message, \Exception $exception): bool
     {
         if (!isset($this->logger)) {
             return false;

--- a/tests/Stash/Test/AbstractItemTest.php
+++ b/tests/Stash/Test/AbstractItemTest.php
@@ -11,6 +11,7 @@
 
 namespace Stash\Test;
 
+use Stash\Exception\ItemKeyMissingException;
 use Stash\Item;
 use Stash\Invalidation;
 use Stash\Utilities;
@@ -115,12 +116,17 @@ abstract class AbstractItemTest extends AbstractTest
 
             $this->assertTrue($stash->set($value)->save(), 'Driver class able to store data type ' . $type);
         }
+    }
+
+    public function testSetException()
+    {
+        $this->expectException(ItemKeyMissingException::class);
 
         $item = $this->getItem();
         $poolStub = new PoolGetDriverStub();
         $poolStub->setDriver(new Ephemeral(array()));
         $item->setPool($poolStub);
-        $this->assertFalse($item->set($this->data), 'Item without key returns false for set.');
+        $item->set($this->data);
     }
 
     /**

--- a/tests/Stash/Test/AbstractItemTestCase.php
+++ b/tests/Stash/Test/AbstractItemTestCase.php
@@ -24,7 +24,7 @@ use Stash\Test\Stubs\PoolGetDriverStub;
  *
  * @todo find out why this has to be abstract to work (see https://github.com/tedivm/Stash/pull/10)
  */
-abstract class AbstractItemTest extends AbstractTest
+abstract class AbstractItemTestCase extends AbstractTestCase
 {
     protected $data = array('string' => 'Hello world!',
                             'complexString' => "\t\t\t\tHello\r\n\rWorld!",

--- a/tests/Stash/Test/AbstractPoolTestCase.php
+++ b/tests/Stash/Test/AbstractPoolTestCase.php
@@ -22,7 +22,7 @@ use Stash\Test\Stubs\DriverExceptionStub;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class AbstractPoolTest extends AbstractTest
+class AbstractPoolTestCase extends AbstractTestCase
 {
     protected $data = array(array('test', 'test'));
     protected $multiData = array('key' => 'value',

--- a/tests/Stash/Test/AbstractTestCase.php
+++ b/tests/Stash/Test/AbstractTestCase.php
@@ -17,7 +17,7 @@ use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-abstract class AbstractTest extends \PHPUnit\Framework\TestCase
+abstract class AbstractTestCase extends \PHPUnit\Framework\TestCase
 {
   use ArraySubsetAsserts;
 

--- a/tests/Stash/Test/Driver/AbstractDriverTestCase.php
+++ b/tests/Stash/Test/Driver/AbstractDriverTestCase.php
@@ -17,7 +17,7 @@ use Stash\Utilities;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-abstract class AbstractDriverTest extends \Stash\Test\AbstractTest
+abstract class AbstractDriverTestCase extends \Stash\Test\AbstractTestCase
 {
     protected $data = array('string' => 'Hello world!',
                             'complexString' => "\t\tHello\r\n\r\'\'World!\"\'\\",

--- a/tests/Stash/Test/Driver/ApcTest.php
+++ b/tests/Stash/Test/Driver/ApcTest.php
@@ -15,7 +15,7 @@ namespace Stash\Test\Driver;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class ApcTest extends AbstractDriverTest
+class ApcTest extends AbstractDriverTestCase
 {
     protected $driverClass = 'Stash\Driver\Apc';
     protected $persistence = true;

--- a/tests/Stash/Test/Driver/CompositeTest.php
+++ b/tests/Stash/Test/Driver/CompositeTest.php
@@ -19,7 +19,7 @@ use Stash\Driver\Ephemeral;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class CompositeTest extends AbstractDriverTest
+class CompositeTest extends AbstractDriverTestCase
 {
     protected $driverClass = 'Stash\Driver\Composite';
     protected $subDrivers;

--- a/tests/Stash/Test/Driver/EphemeralTest.php
+++ b/tests/Stash/Test/Driver/EphemeralTest.php
@@ -18,7 +18,7 @@ use Stash\Test\Stubs\PoolGetDriverStub;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class EphemeralTest extends AbstractDriverTest
+class EphemeralTest extends AbstractDriverTestCase
 {
     protected $driverClass = 'Stash\Driver\Ephemeral';
     protected $persistence = false;

--- a/tests/Stash/Test/Driver/FileSystemTest.php
+++ b/tests/Stash/Test/Driver/FileSystemTest.php
@@ -24,7 +24,7 @@ function strdup($str)
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class FileSystemTest extends AbstractDriverTest
+class FileSystemTest extends AbstractDriverTestCase
 {
     protected $driverClass = 'Stash\Driver\FileSystem';
     protected $extension = '.php';

--- a/tests/Stash/Test/Driver/MemcacheTest.php
+++ b/tests/Stash/Test/Driver/MemcacheTest.php
@@ -19,7 +19,7 @@ use Stash\Item;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class MemcacheTest extends AbstractDriverTest
+class MemcacheTest extends AbstractDriverTestCase
 {
     protected $driverClass = 'Stash\Driver\Memcache';
     protected $extension = 'memcache';

--- a/tests/Stash/Test/Driver/RedisTest.php
+++ b/tests/Stash/Test/Driver/RedisTest.php
@@ -15,7 +15,7 @@ namespace Stash\Test\Driver;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class RedisTest extends AbstractDriverTest
+class RedisTest extends AbstractDriverTestCase
 {
     protected $driverClass = 'Stash\Driver\Redis';
     protected $redisServer = '127.0.0.1';

--- a/tests/Stash/Test/Driver/SqlitePdoSqlite3Test.php
+++ b/tests/Stash/Test/Driver/SqlitePdoSqlite3Test.php
@@ -17,7 +17,7 @@ use Stash\Utilities;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class SqlitePdoSqlite3Test extends AbstractDriverTest
+class SqlitePdoSqlite3Test extends AbstractDriverTestCase
 {
     protected $driverClass = 'Stash\Driver\Sqlite';
     protected $subDriverClass = 'Stash\Driver\Sub\SqlitePdo';

--- a/tests/Stash/Test/ItemLoggerTestCase.php
+++ b/tests/Stash/Test/ItemLoggerTestCase.php
@@ -21,7 +21,7 @@ use Stash\Driver\Ephemeral as Ephemeral;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class ItemLoggerTest extends AbstractTest
+class ItemLoggerTestCase extends AbstractTestCase
 {
     protected function getItem($key, $exceptionDriver = false)
     {

--- a/tests/Stash/Test/ItemTest.php
+++ b/tests/Stash/Test/ItemTest.php
@@ -15,6 +15,6 @@ namespace Stash\Test;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class ItemTest extends AbstractItemTest
+class ItemTest extends AbstractItemTestCase
 {
 }

--- a/tests/Stash/Test/PoolNamespaceTest.php
+++ b/tests/Stash/Test/PoolNamespaceTest.php
@@ -17,7 +17,7 @@ use Stash\Pool;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class PoolNamespaceTest extends AbstractPoolTest
+class PoolNamespaceTest extends AbstractPoolTestCase
 {
     protected function getTestPool($skipNametest = false)
     {

--- a/tests/Stash/Test/PoolTest.php
+++ b/tests/Stash/Test/PoolTest.php
@@ -15,6 +15,6 @@ namespace Stash\Test;
  * @package Stash
  * @author  Robert Hafner <tedivm@tedivm.com>
  */
-class PoolTest extends AbstractPoolTest
+class PoolTest extends AbstractPoolTestCase
 {
 }

--- a/tests/Stash/Test/Stubs/LoggerStub.php
+++ b/tests/Stash/Test/Stubs/LoggerStub.php
@@ -11,6 +11,7 @@
 
 namespace Stash\Test\Stubs;
 
+use Psr\Log\LoggerInterface;
 use Stash;
 
 /**
@@ -21,7 +22,7 @@ use Stash;
  *
  * @codeCoverageIgnore
  */
-class LoggerStub
+class LoggerStub implements LoggerInterface
 {
     public $lastContext;
     public $lastLevel;

--- a/tests/Stash/Test/Stubs/PoolGetDriverStub.php
+++ b/tests/Stash/Test/Stubs/PoolGetDriverStub.php
@@ -13,6 +13,7 @@ namespace Stash\Test\Stubs;
 
 use Psr\Cache\CacheItemInterface;
 use Stash\Interfaces\PoolInterface;
+use Stash\Item;
 
 /**
  *
@@ -24,88 +25,88 @@ class PoolGetDriverStub implements PoolInterface
 {
     protected $driver;
 
-    public function setDriver(\Stash\Interfaces\DriverInterface $driver)
+    public function setDriver(\Stash\Interfaces\DriverInterface $driver): void
     {
         $this->driver = $driver;
     }
 
-    public function getDriver()
+    public function getDriver(): \Stash\Interfaces\DriverInterface
     {
         return $this->driver;
     }
 
-    public function setItemClass($class)
+    public function setItemClass(string $class): bool
     {
         return true;
     }
 
-    public function getItem($key)
+    public function getItem(string $key): CacheItemInterface
+    {
+        return new Item();
+    }
+
+    public function getItems(array $keys = array()): iterable
+    {
+        return [];
+    }
+
+    public function clear(): bool
     {
         return false;
     }
 
-    public function getItems(array $keys = array())
+    public function purge(): bool
     {
         return false;
     }
 
-    public function clear()
+    public function setNamespace(string $namespace = null): bool
     {
         return false;
     }
 
-    public function purge()
+    public function getNamespace(): bool|string
     {
         return false;
     }
 
-    public function setNamespace($namespace = null)
+    public function setLogger($logger): bool
     {
         return false;
     }
 
-    public function getNamespace()
+    public function setInvalidationMethod($invalidation, $arg = null, $arg2 = null): bool
     {
         return false;
     }
 
-    public function setLogger($logger)
+    public function hasItem($key): bool
     {
         return false;
     }
 
-    public function setInvalidationMethod($invalidation, $arg = null, $arg2 = null)
+    public function commit(): bool
     {
         return false;
     }
 
-    public function hasItem($key)
+    public function saveDeferred(CacheItemInterface $item): bool
     {
         return false;
     }
 
-    public function commit()
+    public function save(CacheItemInterface $item): bool
     {
         return false;
     }
 
-    public function saveDeferred(CacheItemInterface $item)
-    {
-        return false;
-    }
-
-    public function save(CacheItemInterface $item)
-    {
-        return false;
-    }
-
-    public function deleteItems(array $keys)
+    public function deleteItems(array $keys): bool
     {
         return false;
     }
 
 
-    public function deleteItem($key)
+    public function deleteItem($key): bool
     {
         return false;
     }


### PR DESCRIPTION
This PR updates the codebase to support `psr/cache` 3.0 and 2.0 (2.0 because 3.0 has narrower types). It makes a couple slight changes to the interfaces and implementations, probably most notable is that `item::set` will now throw an exception rather than return `false` if it's called when the item has no key set.

Resolves #420