### PR TITLE
Use explicit nullable type for PHP 8.4

### DIFF
--- a/src/Stash/Utilities.php
+++ b/src/Stash/Utilities.php
@@ -100,7 +100,7 @@ class Utilities
      * @param  DriverInterface $driver
      * @return string          Path for Stash files
      */
-    public static function getBaseDirectory(DriverInterface $driver = null)
+    public static function getBaseDirectory(?DriverInterface $driver = null)
     {
         $tmp = rtrim(sys_get_temp_dir(), '/\\') . '/';
 


### PR DESCRIPTION
Implicitly marking parameter $driver as nullable is deprecated, the explicit nullable type must be used instead