### PR TITLE
More explicit nullable types for PHP 8.4

### DIFF
--- a/src/Stash/Interfaces/ItemInterface.php
+++ b/src/Stash/Interfaces/ItemInterface.php
@@ -33,7 +33,7 @@ interface ItemInterface extends CacheItemInterface
      * @param array       $key
      * @param string|null $namespace
      */
-    public function setKey(array $key, string $namespace = null): void;
+    public function setKey(array $key, ?string $namespace = null): void;
 
     /**
      * This disables any IO operations by this object, effectively preventing
@@ -91,7 +91,7 @@ interface ItemInterface extends CacheItemInterface
      * @param  null $ttl
      * @return bool
      */
-    public function lock(int $ttl = null): bool;
+    public function lock(?int $ttl = null): bool;
 
     /**
      * Takes and stores data for later retrieval. This data can be any php data,
@@ -110,7 +110,7 @@ interface ItemInterface extends CacheItemInterface
      * @param  int|\DateInterval|null $ttl
      * @return \Stash\Item|bool
      */
-    public function extend(int|\DateInterval $ttl = null): \Stash\Item|bool;
+    public function extend(int|\DateInterval|null $ttl = null): \Stash\Item|bool;
 
     /**
      * Return true if caching is disabled
@@ -163,7 +163,7 @@ interface ItemInterface extends CacheItemInterface
     * @param int|\DateInterval|\DateTimeInterface|null $ttl An integer, date interval, or date
     * @return self
     */
-    public function setTTL(int|\DateInterval|\DateTimeInterface $ttl = null): static;
+    public function setTTL(int|\DateInterval|\DateTimeInterface|null $ttl = null): static;
 
     /**
     * Set the cache invalidation method for this item.

--- a/src/Stash/Interfaces/PoolInterface.php
+++ b/src/Stash/Interfaces/PoolInterface.php
@@ -117,7 +117,7 @@ interface PoolInterface extends CacheItemPoolInterface
      * @return bool
      * @throws \InvalidArgumentException Namespaces must be alphanumeric
      */
-    public function setNamespace(string $namespace = null): bool;
+    public function setNamespace(?string $namespace = null): bool;
 
     /**
      * Returns the current namespace, or false if no namespace was set.

--- a/src/Stash/Item.php
+++ b/src/Stash/Item.php
@@ -173,7 +173,7 @@ class Item implements ItemInterface
      * @param array $key        the key to set for this cache item
      * @param string $namespace the namespace for this cache item
      */
-    public function setKey(array $key, string $namespace = null): void
+    public function setKey(array $key, ?string $namespace = null): void
     {
         $this->namespace = $namespace;
 
@@ -360,7 +360,7 @@ class Item implements ItemInterface
      * @param int $ttl time to live
      * @return bool
      */
-    public function lock(int $ttl = null): bool
+    public function lock(?int $ttl = null): bool
     {
         if ($this->isDisabled()) {
             return true;
@@ -407,7 +407,7 @@ class Item implements ItemInterface
      * @param int|\DateInterval|\DateTimeInterface|null $ttl time to live
      * @return \Stash\Item
      */
-    public function setTTL(int|\DateInterval|\DateTimeInterface $ttl = null): static
+    public function setTTL(int|\DateInterval|\DateTimeInterface|null $ttl = null): static
     {
         if (is_numeric($ttl) || ($ttl instanceof \DateInterval)) {
             return $this->expiresAfter($ttl);
@@ -427,7 +427,7 @@ class Item implements ItemInterface
      * @throws \Stash\Exception\InvalidArgumentException
      * @return \Stash\Item
      */
-    public function expiresAt(int|\DateInterval|\DateTimeInterface $expiration = null): static
+    public function expiresAt(int|\DateInterval|\DateTimeInterface|null $expiration = null): static
     {
         if (!is_null($expiration) && !($expiration instanceof \DateTimeInterface)) {
             # For compatbility with PHP 5.4 we also allow inheriting from the DateTime object.
@@ -526,10 +526,10 @@ class Item implements ItemInterface
     /**
      * {@inheritdoc}
      *
-     * @param int|\DateInterval $ttl time to live
+     * @param int|\DateInterval|null $ttl time to live
      * @return \Stash\Item|false
      */
-    public function extend(int|\DateInterval $ttl = null): \Stash\Item|bool
+    public function extend(int|\DateInterval|null $ttl = null): \Stash\Item|bool
     {
         if ($this->isDisabled()) {
             return false;

--- a/src/Stash/Pool.php
+++ b/src/Stash/Pool.php
@@ -92,7 +92,7 @@ class Pool implements PoolInterface
      *
      * @param DriverInterface $driver
      */
-    public function __construct(DriverInterface $driver = null)
+    public function __construct(?DriverInterface $driver = null)
     {
         if (isset($driver)) {
             $this->setDriver($driver);
@@ -296,7 +296,7 @@ class Pool implements PoolInterface
     /**
      * {@inheritdoc}
      */
-    public function setNamespace(string $namespace = null): bool
+    public function setNamespace(?string $namespace = null): bool
     {
         if (is_null($namespace)) {
             $this->namespace = null;

--- a/src/Stash/Utilities.php
+++ b/src/Stash/Utilities.php
@@ -100,7 +100,7 @@ class Utilities
      * @param  DriverInterface $driver
      * @return string          Path for Stash files
      */
-    public static function getBaseDirectory(DriverInterface $driver = null)
+    public static function getBaseDirectory(?DriverInterface $driver = null)
     {
         $tmp = rtrim(sys_get_temp_dir(), '/\\') . '/';
 

--- a/tests/Stash/Test/Driver/AbstractDriverTestCase.php
+++ b/tests/Stash/Test/Driver/AbstractDriverTestCase.php
@@ -66,7 +66,7 @@ abstract class AbstractDriverTestCase extends \Stash\Test\AbstractTestCase
         }
     }
 
-    protected function getFreshDriver(array $options = null)
+    protected function getFreshDriver(?array $options = null)
     {
         $driverClass = $this->driverClass;
 

--- a/tests/Stash/Test/Stubs/PoolGetDriverStub.php
+++ b/tests/Stash/Test/Stubs/PoolGetDriverStub.php
@@ -60,7 +60,7 @@ class PoolGetDriverStub implements PoolInterface
         return false;
     }
 
-    public function setNamespace(string $namespace = null): bool
+    public function setNamespace(?string $namespace = null): bool
     {
         return false;
     }


### PR DESCRIPTION
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated