### PR TITLE
Fix memcache::set default argument from the deprecated null to false

### DIFF
--- a/src/Stash/Driver/Sub/Memcache.php
+++ b/src/Stash/Driver/Sub/Memcache.php
@@ -65,7 +65,7 @@ class Memcache
             return true;
         }
 
-        return $this->memcached->set($key, array('data' => $value, 'expiration' => $expire), null, $expire);
+        return $this->memcached->set($key, array('data' => $value, 'expiration' => $expire), MEMCACHE_COMPRESSED, $expire);
     }
 
     /**

--- a/src/Stash/Driver/Sub/Memcache.php
+++ b/src/Stash/Driver/Sub/Memcache.php
@@ -65,7 +65,7 @@ class Memcache
             return true;
         }
 
-        return $this->memcached->set($key, array('data' => $value, 'expiration' => $expire), MEMCACHE_COMPRESSED, $expire);
+        return $this->memcached->set($key, array('data' => $value, 'expiration' => $expire), false, $expire);
     }
 
     /**


### PR DESCRIPTION
…not provide null. One option is perhaps MEMCACHE_COMPRESSED