### PR TITLE
RedisTest throws \RedisException, so expect that, not Warning

### DIFF
--- a/tests/Stash/Test/Driver/RedisTest.php
+++ b/tests/Stash/Test/Driver/RedisTest.php
@@ -67,7 +67,7 @@ class RedisTest extends AbstractDriverTestCase
 
     public function testBadDisconnect()
     {
-        $this->expectException('Warning');
+        $this->expectException("RedisException");
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped('This test can not run on HHVM as HHVM throws a different set of errors.');
         }


### PR DESCRIPTION
RedisTest errors with : 

```
1) Stash\Test\Driver\RedisTest::testBadDisconnect
PHPUnit\Framework\Exception: Class "Warning" does not exist

Caused by
ReflectionException: Class "Warning" does not exist
```

Fix by changing class to be RedisException which does seem to be thrown.
