### PR TITLE
Fix Redis invalidation

### DIFF
--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -198,7 +198,7 @@ class Redis extends AbstractDriver
      */
     public function storeData($key, $data, $expiration)
     {
-        $store = array('data' => $data, 'expiration' => $expiration);
+        $store = serialize(array('data' => $data, 'expiration' => $expiration));
         if (is_null($expiration)) {
             return $this->redis->set($this->makeKeyString($key), $store);
         }

--- a/src/Stash/Driver/Redis.php
+++ b/src/Stash/Driver/Redis.php
@@ -198,20 +198,11 @@ class Redis extends AbstractDriver
      */
     public function storeData($key, $data, $expiration)
     {
-        $store = serialize(array('data' => $data, 'expiration' => $expiration));
+        $store = array('data' => $data, 'expiration' => $expiration);
         if (is_null($expiration)) {
             return $this->redis->set($this->makeKeyString($key), $store);
-        } else {
-            $ttl = $expiration - time();
-
-            // Prevent us from even passing a negative ttl'd item to redis,
-            // since it will just round up to zero and cache forever.
-            if ($ttl < 1) {
-                return true;
-            }
-
-            return $this->redis->setex($this->makeKeyString($key), $ttl, $store);
         }
+        return $this->redis->set($this->makeKeyString($key), $store, array('EXAT' => $expiration));
     }
 
     /**


### PR DESCRIPTION
leave expiration handling to Redis and make use of the EXAT option, fixes #433 and #422